### PR TITLE
Add pytest coverage for core logic, MIDI conversion, routing, and history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__/
 MIDI/
 runs/
 **/*.egg-info/
+.pytest_cache/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,33 @@ python app.py
 ```
 Then visit [localhost](http://127.0.0.1:7860/) to access the UI.
 
+## Testing
+
+LoopGPT now has a local pytest suite for deterministic regression coverage. Use it for fast feedback on core music logic, MIDI conversion, history persistence, and provider routing without making live API calls.
+
+Install the development extra if you want to run the tests:
+```sh
+pip install -e ".[dev]"
+```
+
+Run the full suite:
+```sh
+pytest
+```
+
+Run a focused file during development:
+```sh
+pytest tests/test_utils.py
+pytest tests/test_midi_processing.py
+pytest tests/test_runs.py
+```
+
+The pytest suite is intentionally local and hermetic:
+
+- `tests/` covers deterministic behavior in `src/`
+- generated test files use pytest temporary directories instead of writing into repo folders like `generations/`
+- live provider calls, Gradio UI behavior, and optional audio-toolchain behavior are not part of the default pytest suite
+
 ## Usage
 
 1. **Select your parameters**  
@@ -83,6 +110,8 @@ Then visit [localhost](http://127.0.0.1:7860/) to access the UI.
 ## Evaluation Framework
 
 The evaluation framework lives in the `evaluation/` directory and is documented separately in [`evaluation/README.md`](evaluation/README.md).
+
+Use pytest for fast local regression tests, and use the evaluation framework for slower prompt-to-model quality checks across providers. The two workflows are complementary rather than interchangeable.
 
 ## Project Structure
 

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -2,6 +2,8 @@
 
 A unified evaluation framework for testing MIDI loop generation across multiple AI models, with an interactive Plotly Dash dashboard for analyzing results.
 
+This framework is not a replacement for the pytest suite in `tests/`. Use pytest for fast local checks of deterministic code paths such as utility functions, MIDI conversion, history persistence, and provider routing. Use the evaluator when you want to measure prompt-to-model behavior, musical validity, latency, cost, or reasoning-mode differences across real models.
+
 ## File Reference
 
 | File | Description |
@@ -42,12 +44,18 @@ The dashboard opens at `http://127.0.0.1:8050/`.
 
 ## Installation
 
-All dependencies are in `requirements.txt`:
+Install the project first:
 
 ```sh
 python -m venv .venv
 .venv\Scripts\Activate.ps1
-pip install -r requirements.txt
+pip install -e .
+```
+
+If you also want to run the local pytest suite while working on evaluator code, install the development extra:
+
+```sh
+pip install -e ".[dev]"
 ```
 
 Key packages: `dash`, `dash-bootstrap-components`, `pandas`, `plotly`, `mido`, `rich`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/laceyp99/LoopGPT"
 
+[project.optional-dependencies]
+dev = [
+	"pytest>=8.3,<9",
+]
+
 [tool.setuptools]
 include-package-data = true
 py-modules = ["app"]
@@ -38,3 +43,12 @@ py-modules = ["app"]
 where = ["."]
 include = ["src*", "evaluation*"]
 namespaces = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-ra"
+markers = [
+	"slow: marks slower-running tests",
+	"external: marks tests that require external services or binaries",
+]

--- a/src/runs.py
+++ b/src/runs.py
@@ -33,7 +33,7 @@ def generate_midi(
 
     # Ollama models
     if model_choice in ollama_models:
-        loop, messages, loop_cost = ollama_api.loop_gen(prompt, model_choice)
+        loop, messages, loop_cost = ollama_api.loop_gen(prompt, model_choice, temp=temp)
     # OpenAI (unified - handles both standard and reasoning models)
     elif model_choice in model_info["models"]["OpenAI"]:
         loop, messages, loop_cost = openai_api.loop_gen(

--- a/src/utils.py
+++ b/src/utils.py
@@ -273,7 +273,7 @@ def calculate_midi_number(note):
     Returns:
         int: A MIDI number that corresponds to the note.
     """
-    cleaned_pitch = note.pitch.strip().replace("♯", "#").replace("𝄪", "##")
+    cleaned_pitch = note.pitch.strip().replace("♯", "#").replace("♭", "b").replace("𝄪", "##")
     for char in cleaned_pitch:
         if not char.isalpha() and char != "#":
             cleaned_pitch = cleaned_pitch.replace(char, "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import pytest
+from mido import MidiFile
+
+from src.midi_processing import loop_to_midi
+from src.objects import Bar, Bar_G, Loop, Loop_G, Note, Note_G, TimeInformation, TimeInformation_G
+
+
+@pytest.fixture
+def note_factory():
+    def factory(
+        *,
+        pitch="C",
+        octave=4,
+        velocity=96,
+        start_beat=1,
+        duration=16,
+    ):
+        return Note(
+            pitch=pitch,
+            octave=octave,
+            velocity=velocity,
+            time=TimeInformation(start_beat=start_beat, duration=duration),
+        )
+
+    return factory
+
+
+@pytest.fixture
+def note_g_factory():
+    def factory(
+        *,
+        pitch="C",
+        octave=4,
+        velocity=96,
+        start_beat="one",
+        duration="sixteen",
+    ):
+        return Note_G(
+            pitch=pitch,
+            octave=octave,
+            velocity=velocity,
+            time=TimeInformation_G(start_beat=start_beat, duration=duration),
+        )
+
+    return factory
+
+
+@pytest.fixture
+def loop_factory(note_factory):
+    def factory(*, bars=None):
+        if bars is None:
+            bars = [
+                [note_factory(pitch="C", start_beat=1, duration=16)],
+                [note_factory(pitch="E", start_beat=1, duration=16)],
+                [note_factory(pitch="G", start_beat=1, duration=16)],
+                [note_factory(pitch="B", start_beat=1, duration=16)],
+            ]
+
+        return Loop(
+            Bar_1=Bar(num=1, notes=bars[0]),
+            Bar_2=Bar(num=2, notes=bars[1]),
+            Bar_3=Bar(num=3, notes=bars[2]),
+            Bar_4=Bar(num=4, notes=bars[3]),
+        )
+
+    return factory
+
+
+@pytest.fixture
+def loop_g_factory(note_g_factory):
+    def factory(*, bars=None):
+        if bars is None:
+            bars = [
+                [note_g_factory(pitch="C", start_beat="one", duration="sixteen")],
+                [note_g_factory(pitch="E", start_beat="one", duration="sixteen")],
+                [note_g_factory(pitch="G", start_beat="one", duration="sixteen")],
+                [note_g_factory(pitch="B", start_beat="one", duration="sixteen")],
+            ]
+
+        return Loop_G(
+            Bar_1=Bar_G(num=1, notes=bars[0]),
+            Bar_2=Bar_G(num=2, notes=bars[1]),
+            Bar_3=Bar_G(num=3, notes=bars[2]),
+            Bar_4=Bar_G(num=4, notes=bars[3]),
+        )
+
+    return factory
+
+
+@pytest.fixture
+def sample_loop(loop_factory):
+    return loop_factory()
+
+
+@pytest.fixture
+def sample_loop_g(loop_g_factory):
+    return loop_g_factory()
+
+
+@pytest.fixture
+def midi_builder(tmp_path):
+    def factory(loop, *, times_as_string=False, ticks_per_beat=480, filename="test_loop.mid"):
+        midi = MidiFile(ticks_per_beat=ticks_per_beat)
+        loop_to_midi(midi, loop, times_as_string=times_as_string)
+
+        midi_path = Path(tmp_path) / filename
+        midi.save(midi_path)
+        return midi_path
+
+    return factory

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -3,7 +3,8 @@ from mido import MidiFile
 
 def test_sample_loop_fixture_builds_valid_loop(sample_loop):
     assert sample_loop.Bar_1.notes[0].pitch == "C"
-    assert sample_loop.Bar_4.notes[0].time.start_beat == 13
+    assert sample_loop.Bar_1.notes[0].time.start_beat == 1
+    assert sample_loop.Bar_1.notes[0].time.duration == 16
 
 
 def test_midi_builder_writes_midi_file(sample_loop, midi_builder):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,15 @@
+from mido import MidiFile
+
+
+def test_sample_loop_fixture_builds_valid_loop(sample_loop):
+    assert sample_loop.Bar_1.notes[0].pitch == "C"
+    assert sample_loop.Bar_4.notes[0].time.start_beat == 13
+
+
+def test_midi_builder_writes_midi_file(sample_loop, midi_builder):
+    midi_path = midi_builder(sample_loop)
+
+    midi = MidiFile(midi_path)
+
+    assert midi_path.exists()
+    assert len(midi.tracks) == 1

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,174 @@
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src import history
+
+
+@pytest.fixture
+def isolated_history_dir(monkeypatch, tmp_path):
+    generations_dir = tmp_path / "generations"
+    monkeypatch.setattr(history, "GENERATIONS_DIR", str(generations_dir))
+    return generations_dir
+
+
+def _write_binary_file(path: Path, content: bytes = b"test-data"):
+    path.write_bytes(content)
+    return path
+
+
+def _write_generation_metadata(
+    base_dir: Path,
+    *,
+    gen_id: str,
+    timestamp: datetime,
+    prompt: str = "prompt",
+    key: str = "C",
+    scale: str = "major",
+    model: str = "model",
+    provider: str = "OpenAI",
+    temperature: float = 0.0,
+    cost: float | None = None,
+):
+    gen_dir = base_dir / f"gen_{gen_id}"
+    gen_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = history.GenerationMetadata(
+        id=gen_id,
+        timestamp=timestamp,
+        prompt=prompt,
+        key=key,
+        scale=scale,
+        model=model,
+        provider=provider,
+        temperature=temperature,
+        cost=cost,
+        midi_path=str(gen_dir / "loop.mid"),
+        audio_path=str(gen_dir / "loop.mp3"),
+    )
+    (gen_dir / "metadata.json").write_text(metadata.model_dump_json(indent=2), encoding="utf-8")
+    return gen_dir
+
+
+def test_save_generation_copies_files_and_persists_metadata(isolated_history_dir, monkeypatch, tmp_path):
+    monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
+
+    midi_source = _write_binary_file(tmp_path / "source.mid")
+    audio_source = _write_binary_file(tmp_path / "source.mp3")
+
+    gen_id = history.save_generation(
+        midi_path=str(midi_source),
+        prompt="warm rhodes loop",
+        key="D",
+        scale="minor",
+        model="gpt-4o-mini",
+        provider="OpenAI",
+        temperature=0.3,
+        cost=1.5,
+        audio_path=str(audio_source),
+    )
+
+    gen_dir = isolated_history_dir / "gen_fixed_id"
+    metadata = history.get_generation(gen_id)
+
+    assert gen_id == "fixed_id"
+    assert gen_dir.exists()
+    assert (gen_dir / "loop.mid").read_bytes() == midi_source.read_bytes()
+    assert (gen_dir / "loop.mp3").read_bytes() == audio_source.read_bytes()
+    assert metadata is not None
+    assert metadata.prompt == "warm rhodes loop"
+    assert metadata.key == "D"
+    assert metadata.scale == "minor"
+    assert metadata.model == "gpt-4o-mini"
+    assert metadata.provider == "OpenAI"
+    assert metadata.temperature == 0.3
+    assert metadata.cost == 1.5
+
+
+def test_load_history_sorts_newest_first(isolated_history_dir):
+    now = datetime.now()
+    _write_generation_metadata(isolated_history_dir, gen_id="older", timestamp=now - timedelta(days=1))
+    _write_generation_metadata(isolated_history_dir, gen_id="newer", timestamp=now)
+
+    loaded = history.load_history()
+
+    assert [entry.id for entry in loaded] == ["newer", "older"]
+
+
+def test_load_history_skips_missing_and_malformed_metadata(isolated_history_dir):
+    valid_dir = _write_generation_metadata(
+        isolated_history_dir,
+        gen_id="valid",
+        timestamp=datetime.now(),
+    )
+    missing_dir = isolated_history_dir / "gen_missing"
+    missing_dir.mkdir(parents=True)
+    bad_dir = isolated_history_dir / "gen_bad"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "metadata.json").write_text("{not-json}", encoding="utf-8")
+
+    loaded = history.load_history()
+
+    assert [entry.id for entry in loaded] == ["valid"]
+    assert valid_dir.exists()
+    assert missing_dir.exists()
+    assert bad_dir.exists()
+
+
+def test_get_generation_returns_none_for_missing_or_invalid_metadata(isolated_history_dir):
+    missing_result = history.get_generation("missing")
+
+    bad_dir = isolated_history_dir / "gen_broken"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "metadata.json").write_text(json.dumps({"id": "broken"}), encoding="utf-8")
+
+    broken_result = history.get_generation("broken")
+
+    assert missing_result is None
+    assert broken_result is None
+
+
+def test_delete_generation_removes_directory_and_handles_missing_id(isolated_history_dir):
+    _write_generation_metadata(isolated_history_dir, gen_id="delete_me", timestamp=datetime.now())
+
+    assert history.delete_generation("delete_me") is True
+    assert not (isolated_history_dir / "gen_delete_me").exists()
+    assert history.delete_generation("delete_me") is False
+
+
+def test_enforce_limit_removes_oldest_generations(isolated_history_dir, monkeypatch):
+    monkeypatch.setattr(history, "MAX_GENERATIONS", 2)
+    now = datetime.now()
+    _write_generation_metadata(isolated_history_dir, gen_id="oldest", timestamp=now - timedelta(days=2))
+    _write_generation_metadata(isolated_history_dir, gen_id="middle", timestamp=now - timedelta(days=1))
+    _write_generation_metadata(isolated_history_dir, gen_id="newest", timestamp=now)
+
+    history._enforce_limit()
+
+    remaining = {path.name for path in isolated_history_dir.iterdir()}
+
+    assert remaining == {"gen_middle", "gen_newest"}
+
+
+def test_history_count_and_clear_history_reflect_saved_generations(isolated_history_dir):
+    _write_generation_metadata(isolated_history_dir, gen_id="one", timestamp=datetime.now() - timedelta(minutes=1))
+    _write_generation_metadata(isolated_history_dir, gen_id="two", timestamp=datetime.now())
+
+    assert history.get_history_count() == 2
+    assert history.clear_history() == 2
+    assert history.get_history_count() == 0
+
+
+def test_get_provider_for_model_returns_matching_provider_or_ollama_default():
+    model_info = {
+        "models": {
+            "OpenAI": {"gpt-5-mini": {}},
+            "Google": {"gemini-3-flash-preview": {}},
+        }
+    }
+
+    assert history.get_provider_for_model("gpt-5-mini", model_info) == "OpenAI"
+    assert history.get_provider_for_model("gemini-3-flash-preview", model_info) == "Google"
+    assert history.get_provider_for_model("llama3.2:1b", model_info) == "Ollama"

--- a/tests/test_midi_processing.py
+++ b/tests/test_midi_processing.py
@@ -1,0 +1,86 @@
+from mido import Message, MetaMessage, MidiFile, MidiTrack
+
+from src.midi_processing import loop_to_midi, midi_to_loop
+
+
+def test_loop_to_midi_orders_note_off_before_note_on_at_same_tick(loop_factory, note_factory):
+    loop = loop_factory(
+        bars=[
+            [
+                note_factory(pitch="C", start_beat=1, duration=4),
+                note_factory(pitch="E", start_beat=5, duration=4),
+            ],
+            [],
+            [],
+            [],
+        ]
+    )
+    midi = MidiFile(ticks_per_beat=480)
+
+    loop_to_midi(midi, loop, times_as_string=False)
+
+    messages = [msg for msg in midi.tracks[0] if msg.type != "end_of_track"]
+
+    assert [(msg.type, msg.note, msg.time) for msg in messages] == [
+        ("note_on", 60, 0),
+        ("note_off", 60, 480),
+        ("note_on", 64, 0),
+        ("note_off", 64, 480),
+    ]
+
+
+def test_loop_to_midi_clamps_out_of_range_velocity(loop_factory, note_factory):
+    loop = loop_factory(
+        bars=[
+            [note_factory(pitch="C", start_beat=1, duration=4, velocity=200)],
+            [],
+            [],
+            [],
+        ]
+    )
+    midi = MidiFile(ticks_per_beat=480)
+
+    loop_to_midi(midi, loop, times_as_string=False)
+
+    note_messages = [msg for msg in midi.tracks[0] if msg.type != "end_of_track"]
+
+    assert [msg.velocity for msg in note_messages] == [127, 127]
+
+
+def test_midi_to_loop_round_trips_integer_timing(sample_loop, midi_builder):
+    midi_path = midi_builder(sample_loop, times_as_string=False)
+
+    loop = midi_to_loop(str(midi_path), times_as_string=False)
+
+    assert [bar.notes[0].pitch for bar in [loop.Bar_1, loop.Bar_2, loop.Bar_3, loop.Bar_4]] == ["C", "E", "G", "B"]
+    assert all(bar.notes[0].time.start_beat == 1 for bar in [loop.Bar_1, loop.Bar_2, loop.Bar_3, loop.Bar_4])
+    assert all(bar.notes[0].time.duration == 16 for bar in [loop.Bar_1, loop.Bar_2, loop.Bar_3, loop.Bar_4])
+
+
+def test_midi_to_loop_round_trips_string_timing(sample_loop_g, midi_builder):
+    midi_path = midi_builder(sample_loop_g, times_as_string=True)
+
+    loop = midi_to_loop(str(midi_path), times_as_string=True)
+
+    assert [bar.notes[0].pitch for bar in [loop.Bar_1, loop.Bar_2, loop.Bar_3, loop.Bar_4]] == ["C", "E", "G", "B"]
+    assert all(bar.notes[0].time.start_beat.value == "one" for bar in [loop.Bar_1, loop.Bar_2, loop.Bar_3, loop.Bar_4])
+    assert all(bar.notes[0].time.duration.value == "sixteen" for bar in [loop.Bar_1, loop.Bar_2, loop.Bar_3, loop.Bar_4])
+
+
+def test_midi_to_loop_skips_notes_beyond_the_first_four_bars(tmp_path):
+    midi = MidiFile(ticks_per_beat=480)
+    track = MidiTrack()
+    track.append(Message("note_on", note=60, velocity=96, time=7680))
+    track.append(Message("note_off", note=60, velocity=96, time=120))
+    track.append(MetaMessage("end_of_track", time=0))
+    midi.tracks.append(track)
+
+    midi_path = tmp_path / "fifth_bar.mid"
+    midi.save(midi_path)
+
+    loop = midi_to_loop(str(midi_path), times_as_string=False)
+
+    assert loop.Bar_1.notes == []
+    assert loop.Bar_2.notes == []
+    assert loop.Bar_3.notes == []
+    assert loop.Bar_4.notes == []

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import ValidationError
+
+from src.objects import Loop, SixteenthNote, SixteenthNote_G, TimeInformation, TimeInformation_G
+
+
+def test_sixteenth_note_g_from_int_returns_expected_enum_member():
+    assert SixteenthNote_G.from_int(16) is SixteenthNote_G.SIXTEEN
+
+
+def test_sixteenth_note_g_from_int_rejects_out_of_range_values():
+    with pytest.raises(ValueError, match="Invalid sixteenth-note value"):
+        SixteenthNote_G.from_int(17)
+
+
+def test_time_information_coerces_integer_inputs_to_enum_members():
+    time_info = TimeInformation(start_beat=1, duration=16)
+
+    assert time_info.start_beat is SixteenthNote.ONE
+    assert time_info.duration is SixteenthNote.SIXTEEN
+
+
+def test_time_information_g_rejects_unknown_string_values():
+    with pytest.raises(ValidationError):
+        TimeInformation_G(start_beat="zero", duration="sixteen")
+
+
+def test_loop_validates_nested_bar_and_note_data_from_dicts():
+    loop = Loop(
+        Bar_1={"num": 1, "notes": [{"pitch": "C", "octave": 4, "velocity": 96, "time": {"start_beat": 1, "duration": 16}}]},
+        Bar_2={"num": 2, "notes": []},
+        Bar_3={"num": 3, "notes": []},
+        Bar_4={"num": 4, "notes": []},
+    )
+
+    assert loop.Bar_1.notes[0].time.start_beat is SixteenthNote.ONE
+    assert loop.Bar_1.notes[0].time.duration is SixteenthNote.SIXTEEN

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,207 @@
+import pytest
+
+from src import runs
+
+
+def test_generate_midi_routes_to_ollama_and_forwards_temperature(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        runs,
+        "get_model_info",
+        lambda: {"models": {"OpenAI": {}, "Google": {}, "Anthropic": {}}},
+    )
+    monkeypatch.setattr(
+        runs.ollama_api,
+        "get_ollama_status",
+        lambda force_refresh=True: {"available": True, "models": ["llama3"]},
+    )
+
+    def fake_loop_gen(prompt, model, temp=0.0):
+        captured.update({"prompt": prompt, "model": model, "temp": temp})
+        return "loop", ["message"], 0
+
+    monkeypatch.setattr(runs.ollama_api, "loop_gen", fake_loop_gen)
+
+    result = runs.generate_midi("llama3", "write a loop", temp=0.7)
+
+    assert result == ("loop", ["message"], 0)
+    assert captured == {"prompt": "write a loop", "model": "llama3", "temp": 0.7}
+
+
+def test_generate_midi_routes_to_openai_and_forwards_effort(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        runs,
+        "get_model_info",
+        lambda: {
+            "models": {
+                "OpenAI": {"gpt-4o-mini": {}},
+                "Google": {},
+                "Anthropic": {},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        runs.ollama_api,
+        "get_ollama_status",
+        lambda force_refresh=True: {"available": True, "models": []},
+    )
+
+    def fake_loop_gen(prompt, model, temp=0.0, effort=None):
+        captured.update(
+            {"prompt": prompt, "model": model, "temp": temp, "effort": effort}
+        )
+        return "loop", ["message"], 1.25
+
+    monkeypatch.setattr(runs.openai_api, "loop_gen", fake_loop_gen)
+
+    result = runs.generate_midi("gpt-4o-mini", "write a loop", temp=0.2, effort="high")
+
+    assert result == ("loop", ["message"], 1.25)
+    assert captured == {
+        "prompt": "write a loop",
+        "model": "gpt-4o-mini",
+        "temp": 0.2,
+        "effort": "high",
+    }
+
+
+def test_generate_midi_routes_to_gemini_and_forwards_reasoning_options(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        runs,
+        "get_model_info",
+        lambda: {
+            "models": {
+                "OpenAI": {},
+                "Google": {"gemini-2.5-pro": {}},
+                "Anthropic": {},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        runs.ollama_api,
+        "get_ollama_status",
+        lambda force_refresh=True: {"available": True, "models": []},
+    )
+
+    def fake_loop_gen(prompt, model, temp=0.0, use_thinking=None, effort=None):
+        captured.update(
+            {
+                "prompt": prompt,
+                "model": model,
+                "temp": temp,
+                "use_thinking": use_thinking,
+                "effort": effort,
+            }
+        )
+        return "loop", ["message"], 2.5
+
+    monkeypatch.setattr(runs.gemini_api, "loop_gen", fake_loop_gen)
+
+    result = runs.generate_midi(
+        "gemini-2.5-pro",
+        "write a loop",
+        temp=0.4,
+        use_thinking=True,
+        effort="medium",
+    )
+
+    assert result == ("loop", ["message"], 2.5)
+    assert captured == {
+        "prompt": "write a loop",
+        "model": "gemini-2.5-pro",
+        "temp": 0.4,
+        "use_thinking": True,
+        "effort": "medium",
+    }
+
+
+def test_generate_midi_routes_to_claude_and_forwards_reasoning_options(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        runs,
+        "get_model_info",
+        lambda: {
+            "models": {
+                "OpenAI": {},
+                "Google": {},
+                "Anthropic": {"claude-sonnet-4-5": {}},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        runs.ollama_api,
+        "get_ollama_status",
+        lambda force_refresh=True: {"available": True, "models": []},
+    )
+
+    def fake_loop_gen(prompt, model, temp=0.0, use_thinking=False, effort="low"):
+        captured.update(
+            {
+                "prompt": prompt,
+                "model": model,
+                "temp": temp,
+                "use_thinking": use_thinking,
+                "effort": effort,
+            }
+        )
+        return "loop", ["message"], 3.75
+
+    monkeypatch.setattr(runs.claude_api, "loop_gen", fake_loop_gen)
+
+    result = runs.generate_midi(
+        "claude-sonnet-4-5",
+        "write a loop",
+        temp=0.1,
+        use_thinking=True,
+        effort="high",
+    )
+
+    assert result == ("loop", ["message"], 3.75)
+    assert captured == {
+        "prompt": "write a loop",
+        "model": "claude-sonnet-4-5",
+        "temp": 0.1,
+        "use_thinking": True,
+        "effort": "high",
+    }
+
+
+def test_generate_midi_rejects_unknown_models_when_ollama_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        runs,
+        "get_model_info",
+        lambda: {"models": {"OpenAI": {}, "Google": {}, "Anthropic": {}}},
+    )
+    monkeypatch.setattr(
+        runs.ollama_api,
+        "get_ollama_status",
+        lambda force_refresh=True: {"available": False, "models": []},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid Model Selected\. If you intended to use Ollama, it is currently unavailable\.",
+    ):
+        runs.generate_midi("unknown-model", "write a loop")
+
+
+def test_generate_midi_rejects_unknown_models_when_ollama_is_available(monkeypatch):
+    monkeypatch.setattr(
+        runs,
+        "get_model_info",
+        lambda: {"models": {"OpenAI": {}, "Google": {}, "Anthropic": {}}},
+    )
+    monkeypatch.setattr(
+        runs.ollama_api,
+        "get_ollama_status",
+        lambda force_refresh=True: {"available": True, "models": []},
+    )
+
+    with pytest.raises(ValueError, match="Invalid Model Selected"):
+        runs.generate_midi("unknown-model", "write a loop")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,165 @@
+import pytest
+
+from src import utils
+from src.objects import SixteenthNote_G
+
+
+@pytest.mark.parametrize(
+    ("pitch_class", "expected_note"),
+    [
+        (0, "C"),
+        (12, "C"),
+        (-1, "B"),
+        (25, "C#"),
+    ],
+)
+def test_pitch_class_to_note_wraps_chromatic_values(pitch_class, expected_note):
+    assert utils.pitch_class_to_note(pitch_class) == expected_note
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_pitch_class"),
+    [
+        ("C", 0),
+        ("C#", 1),
+        ("Db", 1),
+        ("G♭", 6),
+        ("Cb", 11),
+        ("B#", 0),
+    ],
+)
+def test_note_name_to_pitch_class_supports_enharmonics(name, expected_pitch_class):
+    assert utils.note_name_to_pitch_class(name) == expected_pitch_class
+
+
+def test_note_name_to_pitch_class_rejects_unknown_names():
+    with pytest.raises(ValueError, match="Unrecognized note name"):
+        utils.note_name_to_pitch_class("H")
+
+
+@pytest.mark.parametrize(
+    ("pitch_class", "root_pitch_class", "expected_interval"),
+    [
+        (0, 0, "Root"),
+        (4, 0, "M3"),
+        (11, 4, "P5"),
+        (0, 11, "m2"),
+    ],
+)
+def test_pitch_class_to_interval_uses_wrapped_distance(
+    pitch_class,
+    root_pitch_class,
+    expected_interval,
+):
+    assert utils.pitch_class_to_interval(pitch_class, root_pitch_class) == expected_interval
+
+
+@pytest.mark.parametrize(
+    ("velocity", "expected_color"),
+    [
+        (0, "rgb(45,27,78)"),
+        (127, "rgb(255,107,91)"),
+    ],
+)
+def test_velocity_to_color_maps_expected_endpoint_colors(velocity, expected_color):
+    assert utils.velocity_to_color(velocity) == expected_color
+
+
+@pytest.mark.parametrize(
+    ("midi_pitch", "expected"),
+    [
+        (60, False),
+        (61, True),
+        (66, True),
+        (67, False),
+    ],
+)
+def test_is_black_key_identifies_black_and_white_keys(midi_pitch, expected):
+    assert utils.is_black_key(midi_pitch) is expected
+
+
+@pytest.mark.parametrize(
+    ("sixteenths", "expected"),
+    [
+        (1, "1/16"),
+        (4, "1/4"),
+        (16, "1 bar"),
+        (3, "3/16"),
+    ],
+)
+def test_format_duration_sixteenths_formats_standard_and_fallback_values(sixteenths, expected):
+    assert utils.format_duration_sixteenths(sixteenths) == expected
+
+
+@pytest.mark.parametrize(
+    ("beats", "expected"),
+    [
+        (0.25, "Sixteenth"),
+        (1.0, "Quarter"),
+        (4.0, "Whole"),
+        (1.5, "1.5 beats"),
+    ],
+)
+def test_beats_to_duration_name_formats_standard_and_nonstandard_lengths(beats, expected):
+    assert utils.beats_to_duration_name(beats) == expected
+
+
+def test_scale_returns_expected_note_family_for_c_major():
+    scale_notes = utils.scale("C", "major")
+
+    for note_name in ["C", "D", "E", "F", "G", "A", "B"]:
+        assert note_name in scale_notes
+
+
+def test_scale_rejects_invalid_root_and_mode():
+    with pytest.raises(ValueError, match="Invalid scale letter"):
+        utils.scale("H", "major")
+
+    with pytest.raises(ValueError, match="Invalid scale mode"):
+        utils.scale("C", "dorian")
+
+
+@pytest.mark.parametrize(
+    ("pitch", "octave", "expected_midi_number"),
+    [
+        ("C", 4, 60),
+        ("F♯", 3, 54),
+        ("A♭", 4, 68),
+        ("C♯!", 4, 61),
+    ],
+)
+def test_calculate_midi_number_normalizes_pitch_names(
+    note_factory,
+    pitch,
+    octave,
+    expected_midi_number,
+):
+    note = note_factory(pitch=pitch, octave=octave)
+
+    assert utils.calculate_midi_number(note) == expected_midi_number
+
+
+@pytest.mark.parametrize(
+    ("midi_number", "expected_name", "expected_octave"),
+    [
+        (60, "C", 4),
+        (61, "C#", 4),
+        (73, "C#", 5),
+    ],
+)
+def test_midi_number_to_name_and_octave_returns_canonical_name_and_octave(
+    midi_number,
+    expected_name,
+    expected_octave,
+):
+    note_name, octave = utils.midi_number_to_name_and_octave(midi_number)
+
+    assert note_name == expected_name
+    assert octave == expected_octave
+
+
+def test_sixteenth_converters_round_trip_enum_values():
+    sixteenth_note = utils.int_to_sixteenth_g(16)
+
+    assert sixteenth_note is SixteenthNote_G.SIXTEEN
+    assert utils.convert_sixteenth(sixteenth_note) == 16

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,7 +125,7 @@ def test_scale_rejects_invalid_root_and_mode():
         ("C", 4, 60),
         ("F♯", 3, 54),
         ("A♭", 4, 68),
-        ("C♯!", 4, 61),
+        ("C♯", 4, 61),
     ],
 )
 def test_calculate_midi_number_normalizes_pitch_names(


### PR DESCRIPTION
## Summary
This PR introduces a local pytest suite for LoopGPT and adds deterministic regression coverage around the main non-UI code paths.

The suite now covers:
- core utility and duration helpers
- Pydantic object validation and sixteenth-note enum behavior
- MIDI conversion and round-trip behavior
- provider routing and argument forwarding in the generation router
- history persistence, cleanup, and malformed metadata handling

It also updates the project docs so the testing workflow is clear and so pytest and evaluator runs are positioned as complementary tools rather than interchangeable ones.

## What Changed

- Added pytest project configuration and shared test fixtures
- Added focused tests for utility functions and duration helpers
- Added tests for object validation and MIDI conversion flows
- Added monkeypatched routing tests for provider selection and invalid-model handling
- Added temp-directory based tests for generation history persistence and cleanup
- Updated the main README and evaluation README with testing guidance

## Bug Fixes Included
- Fixed Unicode flat normalization in MIDI note conversion so note names like A♭ are converted correctly
- Fixed temperature forwarding in the Ollama branch of the generation router

## Testing Strategy

The new pytest suite is intentionally local and deterministic.

It covers fast regression checks for core logic without depending on:

- live API calls
- Gradio UI startup
- browser-driven interaction
- optional audio rendering tools

Model-quality and provider-behavior evaluation still belong in the evaluation framework.

## Validation
Ran the full pytest suite locally.

Current result: **65 tests passing**