### PR TITLE
Add Claude Opus 4.8 to the application model registry

### DIFF
--- a/model_list.json
+++ b/model_list.json
@@ -277,6 +277,18 @@
             }
         },
         "Anthropic": {
+            "claude-opus-4-8":{
+                "extended_thinking": true,
+                "effort_options": ["low", "medium", "high", "xhigh", "max"],
+                "max_tokens": 128000,
+                "cost": {
+                    "input": 5.00,
+                    "5m cache input": 6.25,
+                    "1h cache input": 10.00,
+                    "cache hits/refreshes": 0.50,
+                    "output": 25.00
+                }
+            },
             "claude-opus-4-7":{
                 "extended_thinking": true,
                 "effort_options": ["low", "medium", "high", "xhigh", "max"],


### PR DESCRIPTION
## Summary

This PR adds Claude Opus 4.8 to model_list.json under the Anthropic provider so it appears in the existing model selection flow.

It includes the official Claude API model ID, Opus 4.8 pricing, max token limit, and the effort options supported by the model. No provider code or UI changes were needed because the existing Anthropic and app metadata paths already handle effort-driven Claude models.

## Validation:

- Parsed model_list.json successfully
- Confirmed the new Claude Opus 4.8 entry and its key fields