### PR TITLE
Add selectable SoundFonts and explicit audio re-rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ output.mp3
 evaluation/Results/
 evaluation/Datasets/
 soundfonts/*.sf2
+!soundfonts/FM-Piano1 20190916.sf2
 generations/
 __pycache__/
 MIDI/

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ To enable audio playback of generated MIDI loops, you'll need:
    - macOS: `brew install ffmpeg`
    - Linux: `apt install ffmpeg`
 
-3. **SoundFont file** - Piano samples
-   - Download [Salamander Grand Piano](https://freepats.zenvoid.org/Piano/acoustic-grand-piano.html) (~400MB)
-   - Extract and place `SalamanderGrandPiano.sf2` in the `soundfonts/` directory
+3. **Bundled SoundFont** - Piano samples
+   - The repo includes `soundfonts/FM-Piano1 20190916.sf2` as the default playback SoundFont
+   - Source: [FreePats FM Synthesized Piano](https://freepats.zenvoid.org/ElectricPiano/synthesized-piano.html)
+   - License: [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)
+   - You can still add additional `.sf2` files to the `soundfonts/` directory for alternate playback voices
 
 *Note: Audio playback is optional. The app will still generate and download MIDI files without these dependencies.*
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project is a music generation tool that enables users to create 4 bar loops
 
 - Interact with a sleek Gradio interface for an inviting user experience
 - Audio playback to listen to generated MIDI inside the browser
+- Switch between installed SoundFonts, refresh the SoundFont list in-app, and re-render audio without regenerating MIDI
 - Visualize MIDI output using piano roll display
 - Manage your last 20 generations from the history sidebar
 - View/Edit the system prompt that instruct the model through the generation process
@@ -43,6 +44,7 @@ To enable audio playback of generated MIDI loops, you'll need:
    - Source: [FreePats FM Synthesized Piano](https://freepats.zenvoid.org/ElectricPiano/synthesized-piano.html)
    - License: [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)
    - You can still add additional `.sf2` files to the `soundfonts/` directory for alternate playback voices
+   - If the app is already running, click **Refresh SoundFonts** in the UI after adding new files
 
 *Note: Audio playback is optional. The app will still generate and download MIDI files without these dependencies.*
 
@@ -79,11 +81,14 @@ Run a focused file during development:
 pytest tests/test_utils.py
 pytest tests/test_midi_processing.py
 pytest tests/test_runs.py
+pytest tests/test_audio.py
+pytest tests/test_app.py
 ```
 
 The pytest suite is intentionally local and hermetic:
 
 - `tests/` covers deterministic behavior in `src/`
+- audio and app helper tests cover SoundFont discovery, selection, rerender decisions, and history metadata without needing live model calls
 - generated test files use pytest temporary directories instead of writing into repo folders like `generations/`
 - live provider calls, Gradio UI behavior, and optional audio-toolchain behavior are not part of the default pytest suite
 
@@ -98,15 +103,22 @@ The pytest suite is intentionally local and hermetic:
 2. **Generate & Download**  
    - Click **Generate Loop**  
    - Download the MIDI file via the "Download Generated MIDI" widget  
-   - Listen to the audio preview (if playback is configured)
+   - Listen to the audio preview rendered with the currently selected SoundFont (if playback is configured)
    - View the piano-roll image
 
-3. **Browse History**
+3. **Work With SoundFonts**
+   - Use the **SoundFont** dropdown between Playback and MIDI Visualization to choose the render voice
+   - Click **Refresh SoundFonts** if you add new `.sf2` files while the app is already open
+   - Click **Re-render Audio** to audition the currently loaded MIDI through a different SoundFont without regenerating the loop
+   - Loaded history items reopen with their saved audio immediately; re-render only when you want a different SoundFont version
+
+4. **Browse History**
    - Click **History** to open the sidebar
    - Select a previous generation from the dropdown
    - Click **Load** to view/play it, or **Delete** to remove it
+   - History entries remember which SoundFont produced the saved audio preview
 
-4. **Inspect JSON logs**  
+5. **Inspect JSON logs**  
    - `loop.json` records the full message exchange and reasoning
 
 ## Evaluation Framework
@@ -138,7 +150,16 @@ LoopGPT/
 │   ├── objects.py              # Pydantic models (Note, Bar, Loop, _G variants)
 │   ├── utils.py                # MIDI helpers, visualization, message logging
 │   ├── audio.py                # MIDI to audio conversion using FluidSynth
-│   └── history.py              # Session history management (save/load/delete)
+│   └── history.py              # Session history management (save/load/delete/update audio metadata)
+│
+├── tests/                      # Local pytest coverage for deterministic logic and UI helpers
+│   ├── test_app.py             # App helper coverage for SoundFont refresh/rerender logic
+│   ├── test_audio.py           # SoundFont discovery and audio helper coverage
+│   ├── test_history.py         # History persistence and cleanup coverage
+│   ├── test_midi_processing.py # MIDI conversion coverage
+│   ├── test_objects.py         # Pydantic model coverage
+│   ├── test_runs.py            # Provider routing coverage
+│   └── test_utils.py           # Utility helper coverage
 │
 ├── evaluation/                 # Standalone evaluation framework (see evaluation/README.md)
 │   ├── evaluator.py            # Evaluator class -- orchestrates model testing
@@ -150,7 +171,7 @@ LoopGPT/
 │   └── gen_<timestamp>/
 │       ├── loop.mid            # Generated MIDI file
 │       ├── loop.mp3            # Rendered audio (if playback configured)
-│       └── metadata.json       # Generation parameters and info
+│       └── metadata.json       # Generation parameters, audio path, and saved SoundFont info
 │
 ├── runs/                       # Evaluation run outputs (created by evaluator)
 │   ├── run.log                 # Evaluation log file
@@ -160,7 +181,7 @@ LoopGPT/
 │       ├── analysis/           # Exported dashboard charts (HTML)
 │       └── results/            # Per-model, per-prompt, per-key test results
 │
-├── soundfonts/                 # Place SoundFont (.sf2) files here for audio playback
+├── soundfonts/                 # Bundled/default and user-added SoundFont (.sf2) files for playback
 │
 ├── loop.json                   # JSON log of the last MIDI-generation conversation
 └── output.mid                  # The most recently generated MIDI file
@@ -174,3 +195,4 @@ LoopGPT/
 - The quality of generated music depends on the prompt and model parameters.
 - Requires an active internet connection for API calls to model providers.
 - High API usage may incur significant costs.
+- Audio preview still depends on external FluidSynth and FFmpeg installations even though a default SoundFont is bundled with the repo.

--- a/app.py
+++ b/app.py
@@ -260,20 +260,23 @@ def get_rerender_button_update(soundfont_choice=None, midi_path=None):
     return gr.update(interactive=rerender_available(soundfont_choice, midi_path))
 
 
-def refresh_soundfont_controls(soundfont_choice=None, midi_path=None):
-    """Refresh SoundFont UI controls from the filesystem."""
+def get_soundfont_status_message(soundfont_choice=None):
+    """Build the status text for the current SoundFont and playback state."""
     selected_soundfont = get_selected_soundfont(soundfont_choice)
     playback_available, _ = is_playback_available(selected_soundfont)
 
-    if selected_soundfont:
-        status_message = f"Found {len(get_soundfont_choices())} SoundFonts. Selected {selected_soundfont}."
-    else:
-        status_message = get_playback_status_message(selected_soundfont)
+    if playback_available and selected_soundfont:
+        return f"Found {len(get_soundfont_choices())} SoundFonts. Selected {selected_soundfont}."
 
+    return get_playback_status_message(selected_soundfont)
+
+
+def refresh_soundfont_controls(soundfont_choice=None, midi_path=None):
+    """Refresh SoundFont UI controls from the filesystem."""
     return (
         get_soundfont_dropdown_update(soundfont_choice),
         get_rerender_button_update(soundfont_choice, midi_path),
-        status_message,
+        get_soundfont_status_message(soundfont_choice),
     )
 
 
@@ -860,7 +863,7 @@ def create_demo(playback_status=None):
                             # Show playback status if not available
                             if not playback_available:
                                 gr.Markdown(
-                                    f"*Audio playback unavailable. {playback_error}*",
+                                    f"*{get_soundfont_status_message(default_soundfont)}*",
                                     elem_classes=["warning-text"],
                                 )
 

--- a/app.py
+++ b/app.py
@@ -10,13 +10,20 @@ Features:
 
 from src.midi_processing import loop_to_midi
 from src.utils import visualize_midi_plotly, get_model_info
-from src.audio import midi_to_mp3, is_playback_available, get_playback_status_message
+from src.audio import (
+    midi_to_mp3,
+    is_playback_available,
+    get_playback_status_message,
+    list_soundfonts,
+    get_default_soundfont,
+)
 from src.history import (
     save_generation,
     load_history,
     get_generation,
     delete_generation,
     get_provider_for_model,
+    update_generation_audio,
 )
 import src.ollama_api as ollama_api
 import src.runs as runs
@@ -199,6 +206,113 @@ def sync_controls_for_thinking(provider, model_choice, use_thinking):
     return sync_model_capabilities(provider, model_choice, use_thinking)
 
 
+def get_soundfont_choices():
+    """Get the available SoundFont filenames for the UI."""
+    return list_soundfonts()
+
+
+def get_selected_soundfont(soundfont_choice=None):
+    """Normalize the selected SoundFont for the UI."""
+    soundfonts = get_soundfont_choices()
+    if not soundfonts:
+        return None
+
+    if soundfont_choice:
+        requested_name = os.path.basename(soundfont_choice)
+        if requested_name in soundfonts:
+            return requested_name
+
+    default_soundfont = get_default_soundfont()
+    if default_soundfont:
+        default_soundfont_name = os.path.basename(default_soundfont)
+        if default_soundfont_name in soundfonts:
+            return default_soundfont_name
+
+    return soundfonts[0]
+
+
+def get_soundfont_dropdown_update(soundfont_choice=None):
+    """Build a dropdown update for the current SoundFont selection."""
+    return gr.update(
+        choices=get_soundfont_choices(),
+        value=get_selected_soundfont(soundfont_choice),
+    )
+
+
+def refresh_soundfont_controls(soundfont_choice=None):
+    """Refresh SoundFont UI controls from the filesystem."""
+    selected_soundfont = get_selected_soundfont(soundfont_choice)
+    playback_available, _ = is_playback_available(selected_soundfont)
+
+    if selected_soundfont:
+        status_message = f"Found {len(get_soundfont_choices())} SoundFonts. Selected {selected_soundfont}."
+    else:
+        status_message = get_playback_status_message(selected_soundfont)
+
+    return (
+        get_soundfont_dropdown_update(soundfont_choice),
+        gr.update(interactive=playback_available and selected_soundfont is not None),
+        status_message,
+    )
+
+
+def rerender_current_audio(
+    midi_path,
+    soundfont_choice,
+    saved_soundfont,
+    generation_id,
+    current_audio_path,
+):
+    """Re-render the current MIDI file with the selected SoundFont on demand."""
+    if not midi_path:
+        return current_audio_path, "No MIDI file available to re-render.", saved_soundfont, current_audio_path
+
+    if not os.path.exists(midi_path):
+        return current_audio_path, f"MIDI file not found: {midi_path}", saved_soundfont, current_audio_path
+
+    selected_soundfont = get_selected_soundfont(soundfont_choice)
+    if not selected_soundfont:
+        return current_audio_path, get_playback_status_message(soundfont_choice), saved_soundfont, current_audio_path
+
+    if (
+        saved_soundfont == selected_soundfont
+        and current_audio_path
+        and os.path.exists(current_audio_path)
+    ):
+        return (
+            current_audio_path,
+            f"Audio already rendered with {selected_soundfont}.",
+            saved_soundfont,
+            current_audio_path,
+        )
+
+    output_path = current_audio_path or f"{os.path.splitext(midi_path)[0]}.mp3"
+    rendered_audio_path = midi_to_mp3(
+        midi_path,
+        output_path=output_path,
+        soundfont_name=selected_soundfont,
+    )
+    if rendered_audio_path is None:
+        return current_audio_path, get_playback_status_message(selected_soundfont), saved_soundfont, current_audio_path
+
+    persisted_audio_path = rendered_audio_path
+    if generation_id:
+        updated_generation = update_generation_audio(
+            generation_id,
+            rendered_audio_path,
+            soundfont=selected_soundfont,
+        )
+        if updated_generation and updated_generation.audio_path:
+            persisted_audio_path = updated_generation.audio_path
+
+    return (
+        persisted_audio_path,
+        f"Rendered audio with {selected_soundfont}.",
+        selected_soundfont,
+        persisted_audio_path,
+    )
+
+
 def save_prompts(loop_gen_text):
     """This function saves any changes to the loop generation prompt to the text file.
 
@@ -225,6 +339,7 @@ def run_loop(
     model_choice,
     use_thinking,
     effort,
+    soundfont_choice,
     openai_key,
     gemini_key,
     claude_key,
@@ -243,14 +358,16 @@ def run_loop(
         model_choice (str): The model that the user selects from the dropdown.
         use_thinking (bool): Whether to enable extended thinking for supported Claude and Gemini models.
         effort (str): The reasoning effort level for supported OpenAI models.
+         soundfont_choice (str): The selected SoundFont filename for audio rendering.
         openai_key (str): The OpenAI API key that the user inputs in the text box.
         gemini_key (str): The Gemini API key that the user inputs in the text box.
         claude_key (str): The Claude API key that the user inputs in the text box.
 
     Yields:
-        tuple: (file_path, audio_path, visualization, status_message, cancel_button_update) -
-               intermediate yields show progress and keep cancel visible,
-               final yield contains the generated MIDI file, audio, and hides the cancel button.
+         tuple: (file_path, audio_path, visualization, status_message, cancel_button_update,
+             generation_id, saved_soundfont, current_audio_path) - intermediate yields
+             show progress and keep cancel visible, final yield contains the generated MIDI,
+             audio, and persisted audio metadata for rerendering.
     """
     try:
         # If the user provided API keys, update environment variables
@@ -263,9 +380,10 @@ def run_loop(
 
         # Condense the prompt into a single string for the model
         prompt = f"{key} {scale} {description}."
+        selected_soundfont = get_selected_soundfont(soundfont_choice)
 
         # Yield initial status and show cancel button - this is a cancellation checkpoint
-        yield None, None, None, "Working on it...", gr.update(visible=True)
+        yield None, None, None, "Working on it...", gr.update(visible=True), None, None, None
 
         # Run API call in background thread so we can yield periodically for cancellation
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -281,14 +399,14 @@ def run_loop(
             # Poll for completion, yielding periodically to allow cancellation
             while not future.done():
                 time.sleep(0.5)  # Check every 500ms
-                yield None, None, None, "Generating MIDI...", gr.update(visible=True)
+                yield None, None, None, "Generating MIDI...", gr.update(visible=True), None, None, None
 
             # Get the result (will raise exception if the API call failed)
             loop, messages, total_cost = future.result()
 
         print(f"Total cost: {total_cost}")
 
-        yield None, None, None, "Processing MIDI...", gr.update(visible=True)
+        yield None, None, None, "Processing MIDI...", gr.update(visible=True), None, None, None
         # Convert the generated loop into a MIDI file
         midi = MidiFile()
         model_info = get_model_info()
@@ -301,15 +419,15 @@ def run_loop(
         midi.save(output_path)
 
         # Render audio and visualization from MIDI
-        yield None, None, None, "Rendering Audio...", gr.update(visible=True)
-        audio_path = midi_to_mp3(output_path)
+        yield None, None, None, "Rendering Audio...", gr.update(visible=True), None, None, None
+        audio_path = midi_to_mp3(output_path, soundfont_name=selected_soundfont)
         visualization = visualize_midi_plotly(midi)
 
         # Determine provider for history
         provider = get_provider_for_model(model_choice, model_info)
 
         # Save to history
-        save_generation(
+        gen_id = save_generation(
             midi_path=output_path,
             prompt=description,
             key=key,
@@ -319,14 +437,27 @@ def run_loop(
             temperature=temp,
             cost=total_cost,
             audio_path=audio_path,
+            soundfont=selected_soundfont if audio_path else None,
         )
+        saved_generation = get_generation(gen_id)
+        persisted_audio_path = saved_generation.audio_path if saved_generation else audio_path
+        saved_soundfont = saved_generation.soundfont if saved_generation else selected_soundfont
 
         # Final yield with the completed result and hide cancel button
-        yield output_path, audio_path, visualization, "", gr.update(visible=False)
+        yield (
+            output_path,
+            persisted_audio_path,
+            visualization,
+            "",
+            gr.update(visible=False),
+            gen_id,
+            saved_soundfont,
+            persisted_audio_path,
+        )
 
     except Exception as e:
         # Catch any exception and yield the error message, hide cancel button
-        yield None, None, None, str(e), gr.update(visible=False)
+        yield None, None, None, str(e), gr.update(visible=False), None, None, None
 
 
 def toggle_history_sidebar(is_visible):
@@ -423,24 +554,34 @@ def load_history_item(gen_id):
         gen_id (str): The generation ID to load.
 
     Returns:
-        tuple: (midi_path, audio_path, visualization, error_message)
+        tuple: (midi_path, audio_path, soundfont_update, visualization, error_message,
+               generation_id, saved_soundfont, current_audio_path)
     """
     if not gen_id:
-        return None, None, None, "No generation selected"
+        return None, None, get_soundfont_dropdown_update(), None, "No generation selected", None, None, None
 
     gen = get_generation(gen_id)
     if not gen:
-        return None, None, None, f"Generation {gen_id} not found"
+        return None, None, get_soundfont_dropdown_update(), None, f"Generation {gen_id} not found", None, None, None
 
     # Check if files exist
     if not os.path.exists(gen.midi_path):
-        return None, None, None, f"MIDI file not found: {gen.midi_path}"
+        return (
+            None,
+            None,
+            get_soundfont_dropdown_update(gen.soundfont),
+            None,
+            f"MIDI file not found: {gen.midi_path}",
+            None,
+            None,
+            None,
+        )
 
     # Load visualization
     try:
         midi = MidiFile(gen.midi_path)
         visualization = visualize_midi_plotly(midi)
-    except Exception as e:
+    except Exception:
         visualization = None
 
     # Get audio path if it exists
@@ -448,7 +589,16 @@ def load_history_item(gen_id):
         gen.audio_path if gen.audio_path and os.path.exists(gen.audio_path) else None
     )
 
-    return gen.midi_path, audio_path, visualization, ""
+    return (
+        gen.midi_path,
+        audio_path,
+        get_soundfont_dropdown_update(gen.soundfont),
+        visualization,
+        "",
+        gen.id,
+        gen.soundfont,
+        audio_path,
+    )
 
 
 def delete_history_item(gen_id):
@@ -495,8 +645,9 @@ def refresh_history():
 
 def create_demo(playback_status=None):
     """Build and return the Gradio demo."""
+    default_soundfont = get_selected_soundfont()
     if playback_status is None:
-        playback_status = is_playback_available()
+        playback_status = is_playback_available(default_soundfont)
 
     playback_available, playback_error = playback_status
 
@@ -527,6 +678,9 @@ def create_demo(playback_status=None):
     ) as demo:
         # State for sidebar visibility
         sidebar_visible = gr.State(value=False)
+        current_generation_id = gr.State(value=None)
+        current_saved_soundfont = gr.State(value=None)
+        current_audio_path = gr.State(value=None)
 
         # Header with title centered on the original full-width layout
         with gr.Row(elem_classes=["app-header"]):
@@ -633,6 +787,20 @@ def create_demo(playback_status=None):
                                     elem_classes=["warning-text"],
                                 )
 
+                    with gr.Row(equal_height=False):
+                        soundfont_input = gr.Dropdown(
+                            choices=get_soundfont_choices(),
+                            label="SoundFont",
+                            value=default_soundfont,
+                            interactive=True,
+                        )
+                        with gr.Column():
+                            refresh_soundfonts_button = gr.Button("Refresh SoundFonts")
+                            rerender_button = gr.Button(
+                                "Re-render Audio",
+                                interactive=playback_available and default_soundfont is not None,
+                            )
+
                     vis_output = gr.Plot(label="MIDI Visualization")
                     error_message = gr.Textbox(label="Error Message", interactive=False)
 
@@ -679,6 +847,7 @@ def create_demo(playback_status=None):
                             model_choice_input,
                             thinking_checkbox,
                             effort_input,
+                            soundfont_input,
                             openai_key_input,
                             gemini_key_input,
                             claude_key_input,
@@ -689,6 +858,9 @@ def create_demo(playback_status=None):
                             vis_output,
                             error_message,
                             cancel_button,
+                            current_generation_id,
+                            current_saved_soundfont,
+                            current_audio_path,
                         ],
                     )
                     # Cancel button stops waiting for the API response and hides itself
@@ -699,6 +871,9 @@ def create_demo(playback_status=None):
                             None,
                             "Generation cancelled.",
                             gr.update(visible=False),
+                            None,
+                            None,
+                            None,
                         ),
                         outputs=[
                             prog_output,
@@ -706,8 +881,32 @@ def create_demo(playback_status=None):
                             vis_output,
                             error_message,
                             cancel_button,
+                            current_generation_id,
+                            current_saved_soundfont,
+                            current_audio_path,
                         ],
                         cancels=[gen_event],
+                    )
+                    rerender_button.click(
+                        rerender_current_audio,
+                        inputs=[
+                            prog_output,
+                            soundfont_input,
+                            current_saved_soundfont,
+                            current_generation_id,
+                            current_audio_path,
+                        ],
+                        outputs=[
+                            audio_output,
+                            error_message,
+                            current_saved_soundfont,
+                            current_audio_path,
+                        ],
+                    )
+                    refresh_soundfonts_button.click(
+                        refresh_soundfont_controls,
+                        inputs=[soundfont_input],
+                        outputs=[soundfont_input, rerender_button, error_message],
                     )
 
                 # Prompt Editor Tab to allow users to edit the system prompts used in the generation process
@@ -783,7 +982,16 @@ def create_demo(playback_status=None):
         load_btn.click(
             load_history_item,
             inputs=[history_dropdown],
-            outputs=[prog_output, audio_output, vis_output, error_message],
+            outputs=[
+                prog_output,
+                audio_output,
+                soundfont_input,
+                vis_output,
+                error_message,
+                current_generation_id,
+                current_saved_soundfont,
+                current_audio_path,
+            ],
         )
 
         # Delete history item
@@ -811,10 +1019,11 @@ def create_demo(playback_status=None):
 
 def main():
     """Run the Gradio app."""
-    playback_status = is_playback_available()
+    default_soundfont = get_selected_soundfont()
+    playback_status = is_playback_available(default_soundfont)
     playback_available, _ = playback_status
     if not playback_available:
-        print(f"Warning: {get_playback_status_message()}")
+        print(f"Warning: {get_playback_status_message(default_soundfont)}")
 
     demo = create_demo(playback_status=playback_status)
     demo.launch()

--- a/app.py
+++ b/app.py
@@ -622,6 +622,14 @@ def load_history_item(gen_id):
             get_rerender_button_update(gen.soundfont, None),
         )
 
+    missing_soundfont_message = ""
+    if gen.soundfont:
+        saved_soundfont_name = os.path.basename(gen.soundfont)
+        if saved_soundfont_name not in get_soundfont_choices():
+            missing_soundfont_message = (
+                f"Previously used SoundFont: {saved_soundfont_name} (missing)"
+            )
+
     # Load visualization
     try:
         midi = MidiFile(gen.midi_path)
@@ -639,7 +647,7 @@ def load_history_item(gen_id):
         audio_path,
         get_soundfont_dropdown_update(gen.soundfont),
         visualization,
-        "",
+        missing_soundfont_message,
         gen.id,
         gen.soundfont,
         audio_path,

--- a/app.py
+++ b/app.py
@@ -239,7 +239,28 @@ def get_soundfont_dropdown_update(soundfont_choice=None):
     )
 
 
-def refresh_soundfont_controls(soundfont_choice=None):
+def has_active_rerender_target(midi_path):
+    """Return whether the UI currently has a MIDI file available to rerender."""
+    return bool(midi_path and os.path.exists(midi_path))
+
+
+def rerender_available(soundfont_choice=None, midi_path=None):
+    """Return whether rerendering should be enabled for the current UI state."""
+    selected_soundfont = get_selected_soundfont(soundfont_choice)
+    playback_available, _ = is_playback_available(selected_soundfont)
+    return (
+        playback_available
+        and selected_soundfont is not None
+        and has_active_rerender_target(midi_path)
+    )
+
+
+def get_rerender_button_update(soundfont_choice=None, midi_path=None):
+    """Build a button update for the current rerender availability."""
+    return gr.update(interactive=rerender_available(soundfont_choice, midi_path))
+
+
+def refresh_soundfont_controls(soundfont_choice=None, midi_path=None):
     """Refresh SoundFont UI controls from the filesystem."""
     selected_soundfont = get_selected_soundfont(soundfont_choice)
     playback_available, _ = is_playback_available(selected_soundfont)
@@ -251,7 +272,7 @@ def refresh_soundfont_controls(soundfont_choice=None):
 
     return (
         get_soundfont_dropdown_update(soundfont_choice),
-        gr.update(interactive=playback_available and selected_soundfont is not None),
+        get_rerender_button_update(soundfont_choice, midi_path),
         status_message,
     )
 
@@ -555,14 +576,34 @@ def load_history_item(gen_id):
 
     Returns:
         tuple: (midi_path, audio_path, soundfont_update, visualization, error_message,
-               generation_id, saved_soundfont, current_audio_path)
+               generation_id, saved_soundfont, current_audio_path, rerender_update)
     """
     if not gen_id:
-        return None, None, get_soundfont_dropdown_update(), None, "No generation selected", None, None, None
+        return (
+            None,
+            None,
+            get_soundfont_dropdown_update(),
+            None,
+            "No generation selected",
+            None,
+            None,
+            None,
+            get_rerender_button_update(),
+        )
 
     gen = get_generation(gen_id)
     if not gen:
-        return None, None, get_soundfont_dropdown_update(), None, f"Generation {gen_id} not found", None, None, None
+        return (
+            None,
+            None,
+            get_soundfont_dropdown_update(),
+            None,
+            f"Generation {gen_id} not found",
+            None,
+            None,
+            None,
+            get_rerender_button_update(),
+        )
 
     # Check if files exist
     if not os.path.exists(gen.midi_path):
@@ -575,6 +616,7 @@ def load_history_item(gen_id):
             None,
             None,
             None,
+            get_rerender_button_update(gen.soundfont, None),
         )
 
     # Load visualization
@@ -598,38 +640,73 @@ def load_history_item(gen_id):
         gen.id,
         gen.soundfont,
         audio_path,
+        get_rerender_button_update(gen.soundfont, gen.midi_path),
     )
 
 
-def delete_history_item(gen_id):
+def delete_history_item(
+    gen_id,
+    current_generation_id=None,
+    soundfont_choice=None,
+    midi_path=None,
+    current_saved_soundfont=None,
+    current_audio_path=None,
+):
     """Delete a history item.
 
     Args:
         gen_id (str): The generation ID to delete.
 
     Returns:
-        tuple: (dropdown_update, status_message, history_html)
+        tuple: (dropdown_update, status_message, history_html, midi_path, audio_path,
+               visualization, generation_id, saved_soundfont, current_audio_path,
+               rerender_update)
     """
     if not gen_id:
         return (
             gr.update(choices=get_history_choices(), value=None),
             "No generation selected",
             render_history_html(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            current_generation_id,
+            current_saved_soundfont,
+            current_audio_path,
+            get_rerender_button_update(soundfont_choice, midi_path),
         )
 
     success = delete_generation(gen_id)
     choices = get_history_choices()
+    deleted_active_generation = success and gen_id == current_generation_id
     if success:
         return (
             gr.update(choices=choices, value=None),
             "Deleted generation",
             render_history_html(),
+            None if deleted_active_generation else gr.update(),
+            None if deleted_active_generation else gr.update(),
+            None if deleted_active_generation else gr.update(),
+            None if deleted_active_generation else current_generation_id,
+            None if deleted_active_generation else current_saved_soundfont,
+            None if deleted_active_generation else current_audio_path,
+            get_rerender_button_update(
+                soundfont_choice,
+                None if deleted_active_generation else midi_path,
+            ),
         )
     else:
         return (
             gr.update(choices=choices, value=None),
             "Failed to delete generation",
             render_history_html(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            current_generation_id,
+            current_saved_soundfont,
+            current_audio_path,
+            get_rerender_button_update(soundfont_choice, midi_path),
         )
 
 
@@ -798,7 +875,7 @@ def create_demo(playback_status=None):
                             refresh_soundfonts_button = gr.Button("Refresh SoundFonts")
                             rerender_button = gr.Button(
                                 "Re-render Audio",
-                                interactive=playback_available and default_soundfont is not None,
+                                interactive=rerender_available(default_soundfont, None),
                             )
 
                     vis_output = gr.Plot(label="MIDI Visualization")
@@ -886,6 +963,10 @@ def create_demo(playback_status=None):
                             current_audio_path,
                         ],
                         cancels=[gen_event],
+                    ).then(
+                        get_rerender_button_update,
+                        inputs=[soundfont_input, prog_output],
+                        outputs=[rerender_button],
                     )
                     rerender_button.click(
                         rerender_current_audio,
@@ -905,7 +986,7 @@ def create_demo(playback_status=None):
                     )
                     refresh_soundfonts_button.click(
                         refresh_soundfont_controls,
-                        inputs=[soundfont_input],
+                        inputs=[soundfont_input, prog_output],
                         outputs=[soundfont_input, rerender_button, error_message],
                     )
 
@@ -991,14 +1072,33 @@ def create_demo(playback_status=None):
                 current_generation_id,
                 current_saved_soundfont,
                 current_audio_path,
+                rerender_button,
             ],
         )
 
         # Delete history item
         delete_btn.click(
             delete_history_item,
-            inputs=[history_dropdown],
-            outputs=[history_dropdown, history_status, history_html],
+            inputs=[
+                history_dropdown,
+                current_generation_id,
+                soundfont_input,
+                prog_output,
+                current_saved_soundfont,
+                current_audio_path,
+            ],
+            outputs=[
+                history_dropdown,
+                history_status,
+                history_html,
+                prog_output,
+                audio_output,
+                vis_output,
+                current_generation_id,
+                current_saved_soundfont,
+                current_audio_path,
+                rerender_button,
+            ],
         )
 
         # Refresh history
@@ -1010,6 +1110,10 @@ def create_demo(playback_status=None):
         # Also refresh history after generation completes (when cancel button becomes hidden)
         # We do this by having the generation flow trigger a refresh
         gen_event.then(
+            get_rerender_button_update,
+            inputs=[soundfont_input, prog_output],
+            outputs=[rerender_button],
+        ).then(
             refresh_history,
             outputs=[history_dropdown, history_html],
         )

--- a/soundfonts/README.md
+++ b/soundfonts/README.md
@@ -6,16 +6,23 @@ This directory contains SoundFont (`.sf2`) files used for MIDI audio playback.
 
 The project ships with `FM-Piano1 20190916.sf2` as the default bundled SoundFont.
 
-- Source: https://freepats.zenvoid.org/Piano/acoustic-grand-piano.html
+- Source: https://freepats.zenvoid.org/ElectricPiano/synthesized-piano.html
 - Upstream instrument: `FM-Piano1`
-- Variant: small size, bright sound variation
+- Type: compact synthesized piano
 - License: Creative Commons CC0 1.0
 
 This keeps audio playback setup smaller than the older Salamander-based flow while still giving the app a piano SoundFont out of the box.
 
 ## Adding More SoundFonts
 
-Any compatible `.sf2` file can live in this directory. Later UI changes will allow switching between multiple installed SoundFonts from the app.
+Any compatible `.sf2` file can live in this directory.
+
+Current app behavior:
+
+- The Gradio app lists installed `.sf2` files in the **SoundFont** dropdown.
+- If you add a new SoundFont while the app is already running, click **Refresh SoundFonts** to reload the directory.
+- Use **Re-render Audio** to audition the currently loaded MIDI with a different SoundFont without regenerating the loop.
+- Saved history entries remember which SoundFont produced their stored audio preview.
 
 Examples that the current audio module will auto-detect include:
 

--- a/soundfonts/README.md
+++ b/soundfonts/README.md
@@ -1,23 +1,31 @@
 # SoundFonts Directory
 
-Place your SoundFont (.sf2) files here for MIDI audio playback.
+This directory contains SoundFont (`.sf2`) files used for MIDI audio playback.
 
-## Recommended SoundFont
+## Bundled Default
 
-**Salamander Grand Piano** - A high-quality sampled grand piano
+The project ships with `FM-Piano1 20190916.sf2` as the default bundled SoundFont.
 
-Navigate to https://freepats.zenvoid.org/Piano/acoustic-grand-piano.html
+- Source: https://freepats.zenvoid.org/Piano/acoustic-grand-piano.html
+- Upstream instrument: `FM-Piano1`
+- Variant: small size, bright sound variation
+- License: Creative Commons CC0 1.0
 
-1. Scroll down to `Salamander Grand Piano` and Download the SF2 option.
-2. Extract the archive
-3. Copy `SalamanderGrandPiano.sf2` to this directory
+This keeps audio playback setup smaller than the older Salamander-based flow while still giving the app a piano SoundFont out of the box.
 
-## Alternative SoundFonts
+## Adding More SoundFonts
 
-Any GM-compatible SoundFont will work. The audio module will automatically detect:
+Any compatible `.sf2` file can live in this directory. Later UI changes will allow switching between multiple installed SoundFonts from the app.
+
+Examples that the current audio module will auto-detect include:
+
 - `SalamanderGrandPiano.sf2`
 - `salamander-grand-piano.sf2`
 - `piano.sf2`
 - `GeneralUser.sf2`
 - `FluidR3_GM.sf2`
 - Any other `.sf2` file in this directory
+
+## Current Limits
+
+The app still requires FluidSynth and FFmpeg to be installed separately for audio rendering. Bundling the default SoundFont only removes the manual SoundFont download step.

--- a/src/audio.py
+++ b/src/audio.py
@@ -6,7 +6,7 @@ using FluidSynth for synthesis and pydub for MP3 encoding.
 Requires:
     - FluidSynth system library installed
     - FFmpeg installed (for MP3 encoding)
-    - A SoundFont file (Salamander Grand Piano recommended)
+    - At least one SoundFont file in the soundfonts directory
 """
 
 from midi2audio import FluidSynth
@@ -24,13 +24,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Path to the SoundFont file - Salamander Grand Piano
 SOUNDFONT_DIR = os.path.join(os.path.dirname(__file__), "..", "soundfonts")
-SOUNDFONT_FILENAME = "SalamanderGrandPiano.sf2"
-SOUNDFONT_PATH = os.path.join(SOUNDFONT_DIR, SOUNDFONT_FILENAME)
-
-# Alternative soundfont names to search for
-ALTERNATIVE_SOUNDFONTS = [
+# Preferred SoundFont filenames searched in order.
+DEFAULT_SOUNDFONT_CANDIDATES = [
+    "FM-Piano1 20190916.sf2",
     "SalamanderGrandPiano.sf2",
     "salamander-grand-piano.sf2",
     "piano.sf2",
@@ -39,32 +36,76 @@ ALTERNATIVE_SOUNDFONTS = [
 ]
 
 
-def find_soundfont() -> str | None:
-    """Search for an available SoundFont file.
+def list_soundfonts() -> list[str]:
+    """List the available SoundFont filenames.
 
     Returns:
-        str: Path to a SoundFont file if found, None otherwise.
+        list[str]: Sorted `.sf2` filenames in the soundfonts directory.
     """
-    # Check primary path first
-    if os.path.exists(SOUNDFONT_PATH):
-        return SOUNDFONT_PATH
+    if not os.path.exists(SOUNDFONT_DIR):
+        return []
 
-    # Search for alternatives in the soundfonts directory
-    if os.path.exists(SOUNDFONT_DIR):
-        for sf_name in ALTERNATIVE_SOUNDFONTS:
-            sf_path = os.path.join(SOUNDFONT_DIR, sf_name)
-            if os.path.exists(sf_path):
-                logger.info(f"Found alternative SoundFont: {sf_name}")
-                return sf_path
+    return sorted(
+        [file for file in os.listdir(SOUNDFONT_DIR) if file.lower().endswith(".sf2")],
+        key=str.lower,
+    )
 
-        # Check for any .sf2 file in the directory
-        for file in os.listdir(SOUNDFONT_DIR):
-            if file.lower().endswith(".sf2"):
-                sf_path = os.path.join(SOUNDFONT_DIR, file)
-                logger.info(f"Found SoundFont: {file}")
-                return sf_path
 
-    return None
+def get_default_soundfont() -> str | None:
+    """Resolve the default SoundFont path.
+
+    Returns:
+        str | None: Path to the preferred available SoundFont, or None.
+    """
+    available_soundfonts = list_soundfonts()
+    if not available_soundfonts:
+        return None
+
+    available_lookup = {name.lower(): name for name in available_soundfonts}
+
+    for soundfont_name in DEFAULT_SOUNDFONT_CANDIDATES:
+        matched_name = available_lookup.get(soundfont_name.lower())
+        if matched_name:
+            return os.path.join(SOUNDFONT_DIR, matched_name)
+
+    fallback_soundfont = available_soundfonts[0]
+    logger.info(f"Falling back to SoundFont: {fallback_soundfont}")
+    return os.path.join(SOUNDFONT_DIR, fallback_soundfont)
+
+
+def resolve_soundfont(soundfont_name: str | None = None) -> str | None:
+    """Resolve an explicit or default SoundFont path.
+
+    Args:
+        soundfont_name (str | None): Optional SoundFont filename or path.
+
+    Returns:
+        str | None: Path to a SoundFont file if found, None otherwise.
+    """
+    if soundfont_name:
+        if os.path.exists(soundfont_name):
+            return soundfont_name
+
+        requested_name = os.path.basename(soundfont_name)
+        requested_path = os.path.join(SOUNDFONT_DIR, requested_name)
+        if os.path.exists(requested_path):
+            return requested_path
+
+        return None
+
+    return get_default_soundfont()
+
+
+def find_soundfont(soundfont_name: str | None = None) -> str | None:
+    """Backwards-compatible wrapper for SoundFont resolution.
+
+    Args:
+        soundfont_name (str | None): Optional SoundFont filename or path.
+
+    Returns:
+        str | None: Path to a SoundFont file if found, None otherwise.
+    """
+    return resolve_soundfont(soundfont_name)
 
 
 def is_fluidsynth_available() -> bool:
@@ -85,7 +126,7 @@ def is_ffmpeg_available() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
-def is_playback_available() -> tuple[bool, str | None]:
+def is_playback_available(soundfont_name: str | None = None) -> tuple[bool, str | None]:
     """Check if audio playback is available.
 
     Verifies that all required components are present:
@@ -106,11 +147,16 @@ def is_playback_available() -> tuple[bool, str | None]:
     if not is_ffmpeg_available():
         issues.append("FFmpeg is not installed or not in PATH")
 
-    if find_soundfont() is None:
-        issues.append(
-            f"No SoundFont file found in '{SOUNDFONT_DIR}'. "
-            f"Please download Salamander Grand Piano and place the .sf2 file there."
-        )
+    resolved_soundfont = find_soundfont(soundfont_name)
+    if resolved_soundfont is None:
+        if soundfont_name:
+            issues.append(
+                f"Requested SoundFont '{os.path.basename(soundfont_name)}' was not found in '{SOUNDFONT_DIR}'."
+            )
+        else:
+            issues.append(
+                f"No SoundFont file found in '{SOUNDFONT_DIR}'. Add a .sf2 file to enable audio playback."
+            )
 
     if issues:
         return False, "; ".join(issues)
@@ -118,13 +164,18 @@ def is_playback_available() -> tuple[bool, str | None]:
     return True, None
 
 
-def midi_to_mp3(midi_path: str, output_path: str | None = None) -> str | None:
+def midi_to_mp3(
+    midi_path: str,
+    output_path: str | None = None,
+    soundfont_name: str | None = None,
+) -> str | None:
     """Convert a MIDI file to MP3 audio using FluidSynth.
 
     Args:
         midi_path (str): Path to the input MIDI file.
         output_path (str, optional): Path for the output MP3 file.
             If not provided, uses the same name as the MIDI file with .mp3 extension.
+        soundfont_name (str, optional): SoundFont filename or path to use.
 
     Returns:
         str | None: Path to the generated MP3 file, or None if conversion failed.
@@ -136,7 +187,7 @@ def midi_to_mp3(midi_path: str, output_path: str | None = None) -> str | None:
         raise FileNotFoundError(f"MIDI file not found: {midi_path}")
 
     # Check if playback is available
-    available, error = is_playback_available()
+    available, error = is_playback_available(soundfont_name)
     if not available:
         logger.warning(f"Audio playback not available: {error}")
         return None
@@ -147,7 +198,7 @@ def midi_to_mp3(midi_path: str, output_path: str | None = None) -> str | None:
         output_path = f"{base_name}.mp3"
 
     # Find the soundfont
-    soundfont_path = find_soundfont()
+    soundfont_path = find_soundfont(soundfont_name)
     if soundfont_path is None:
         logger.error("No SoundFont file available")
         return None
@@ -183,16 +234,16 @@ def midi_to_mp3(midi_path: str, output_path: str | None = None) -> str | None:
                 pass
 
 
-def get_playback_status_message() -> str:
+def get_playback_status_message(soundfont_name: str | None = None) -> str:
     """Get a user-friendly status message about playback availability.
 
     Returns:
         str: A message describing the playback status and any setup required.
     """
-    available, error = is_playback_available()
+    available, error = is_playback_available(soundfont_name)
 
     if available:
-        soundfont = find_soundfont()
+        soundfont = find_soundfont(soundfont_name)
         sf_name = os.path.basename(soundfont) if soundfont else "Unknown"
         return f"Audio playback ready (using {sf_name})"
 
@@ -207,12 +258,13 @@ def get_playback_status_message() -> str:
     if not is_ffmpeg_available():
         instructions.append("  - Install FFmpeg: https://ffmpeg.org/download.html")
 
-    if find_soundfont() is None:
-        instructions.append(
-            "  - Download Salamander Grand Piano SoundFont and place in 'soundfonts/' folder"
-        )
-        instructions.append(
-            "    https://freepats.zenvoid.org/Piano/acoustic-grand-piano.html"
-        )
+    resolved_soundfont = find_soundfont(soundfont_name)
+    if resolved_soundfont is None:
+        if soundfont_name:
+            instructions.append(
+                f"  - Add the requested SoundFont '{os.path.basename(soundfont_name)}' to 'soundfonts/'"
+            )
+        else:
+            instructions.append("  - Add a `.sf2` SoundFont file to the 'soundfonts/' folder")
 
     return "\n".join(instructions)

--- a/src/audio.py
+++ b/src/audio.py
@@ -247,16 +247,25 @@ def get_playback_status_message(soundfont_name: str | None = None) -> str:
         sf_name = os.path.basename(soundfont) if soundfont else "Unknown"
         return f"Audio playback ready (using {sf_name})"
 
-    # Build setup instructions
-    instructions = ["Audio playback is not available. Setup required:"]
+    dependency_instructions = []
 
     if not is_fluidsynth_available():
-        instructions.append(
+        dependency_instructions.append(
             "  - Install FluidSynth: https://github.com/FluidSynth/fluidsynth/releases"
         )
 
     if not is_ffmpeg_available():
-        instructions.append("  - Install FFmpeg: https://ffmpeg.org/download.html")
+        dependency_instructions.append(
+            "  - Install FFmpeg: https://ffmpeg.org/download.html"
+        )
+
+    if dependency_instructions:
+        return "\n".join([
+            "Audio playback is not available. Setup required:",
+            *dependency_instructions,
+        ])
+
+    instructions = ["Audio playback is not available. Setup required:"]
 
     resolved_soundfont = find_soundfont(soundfont_name)
     if resolved_soundfont is None:

--- a/src/history.py
+++ b/src/history.py
@@ -50,6 +50,7 @@ class GenerationMetadata(BaseModel):
         cost: API cost if available.
         midi_path: Path to the MIDI file.
         audio_path: Path to the audio file (None if synthesis failed).
+        soundfont: SoundFont filename used to render the audio file.
     """
 
     id: str
@@ -63,6 +64,7 @@ class GenerationMetadata(BaseModel):
     cost: Optional[float] = None
     midi_path: str
     audio_path: Optional[str] = None
+    soundfont: Optional[str] = None
 
 
 def _ensure_generations_dir() -> None:
@@ -119,6 +121,7 @@ def save_generation(
     temperature: float,
     cost: Optional[float] = None,
     audio_path: Optional[str] = None,
+    soundfont: Optional[str] = None,
 ) -> str:
     """Save a generation to history.
 
@@ -135,6 +138,7 @@ def save_generation(
         temperature: Temperature setting.
         cost: API cost (optional).
         audio_path: Path to rendered audio file (optional).
+        soundfont: SoundFont filename used to render the audio file (optional).
 
     Returns:
         str: The generation ID.
@@ -169,6 +173,7 @@ def save_generation(
         cost=cost,
         midi_path=dest_midi_path,
         audio_path=dest_audio_path,
+        soundfont=soundfont,
     )
 
     # Save metadata

--- a/src/history.py
+++ b/src/history.py
@@ -189,6 +189,45 @@ def save_generation(
     return gen_id
 
 
+def update_generation_audio(
+    gen_id: str,
+    audio_path: Optional[str],
+    soundfont: Optional[str] = None,
+) -> Optional[GenerationMetadata]:
+    """Update the stored audio path and SoundFont for an existing generation.
+
+    Args:
+        gen_id: The generation ID.
+        audio_path: Path to the rendered audio file.
+        soundfont: SoundFont filename used to render the audio file.
+
+    Returns:
+        GenerationMetadata or None if the generation does not exist.
+    """
+    metadata = get_generation(gen_id)
+    if metadata is None:
+        return None
+
+    gen_dir = _get_generation_dir(gen_id)
+    metadata_path = os.path.join(gen_dir, "metadata.json")
+
+    dest_audio_path = metadata.audio_path
+    if audio_path and os.path.exists(audio_path):
+        dest_audio_path = os.path.join(gen_dir, "loop.mp3")
+        if os.path.abspath(audio_path) != os.path.abspath(dest_audio_path):
+            shutil.copy2(audio_path, dest_audio_path)
+        else:
+            dest_audio_path = audio_path
+
+    metadata.audio_path = dest_audio_path
+    metadata.soundfont = soundfont
+
+    with open(metadata_path, "w") as f:
+        f.write(metadata.model_dump_json(indent=2))
+
+    return metadata
+
+
 def load_history() -> list[GenerationMetadata]:
     """Load all generations from history.
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import app
+
+
+def _write_binary_file(path: Path, content: bytes = b"data") -> Path:
+    path.write_bytes(content)
+    return path
+
+
+def test_get_selected_soundfont_prefers_requested_choice(monkeypatch):
+    monkeypatch.setattr(
+        app,
+        "get_soundfont_choices",
+        lambda: ["FM-Piano1 20190916.sf2", "custom.sf2"],
+    )
+    monkeypatch.setattr(
+        app,
+        "get_default_soundfont",
+        lambda: str(Path("soundfonts") / "FM-Piano1 20190916.sf2"),
+    )
+
+    selected_soundfont = app.get_selected_soundfont("custom.sf2")
+
+    assert selected_soundfont == "custom.sf2"
+
+
+def test_rerender_current_audio_skips_existing_matching_soundfont(monkeypatch, tmp_path):
+    midi_path = _write_binary_file(tmp_path / "loop.mid")
+    audio_path = _write_binary_file(tmp_path / "loop.mp3")
+
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "custom.sf2")
+
+    def fail_render(*args, **kwargs):
+        raise AssertionError("midi_to_mp3 should not be called when the audio is already current")
+
+    monkeypatch.setattr(app, "midi_to_mp3", fail_render)
+
+    rerendered_audio_path, status, saved_soundfont, current_audio_path = app.rerender_current_audio(
+        str(midi_path),
+        "custom.sf2",
+        "custom.sf2",
+        "gen_1",
+        str(audio_path),
+    )
+
+    assert rerendered_audio_path == str(audio_path)
+    assert status == "Audio already rendered with custom.sf2."
+    assert saved_soundfont == "custom.sf2"
+    assert current_audio_path == str(audio_path)
+
+
+def test_rerender_current_audio_updates_saved_generation(monkeypatch, tmp_path):
+    midi_path = _write_binary_file(tmp_path / "loop.mid")
+    rendered_audio = _write_binary_file(tmp_path / "rendered.mp3", b"rendered")
+
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "custom.sf2")
+    monkeypatch.setattr(
+        app,
+        "midi_to_mp3",
+        lambda midi_path, output_path=None, soundfont_name=None: str(rendered_audio),
+    )
+    monkeypatch.setattr(
+        app,
+        "update_generation_audio",
+        lambda gen_id, audio_path, soundfont=None: SimpleNamespace(
+            audio_path=str(tmp_path / "saved-loop.mp3"),
+            soundfont=soundfont,
+        ),
+    )
+
+    rerendered_audio_path, status, saved_soundfont, current_audio_path = app.rerender_current_audio(
+        str(midi_path),
+        "custom.sf2",
+        "old.sf2",
+        "gen_1",
+        None,
+    )
+
+    assert rerendered_audio_path == str(tmp_path / "saved-loop.mp3")
+    assert status == "Rendered audio with custom.sf2."
+    assert saved_soundfont == "custom.sf2"
+    assert current_audio_path == str(tmp_path / "saved-loop.mp3")
+
+
+def test_refresh_soundfont_controls_updates_dropdown_choices(monkeypatch):
+    monkeypatch.setattr(app, "get_soundfont_choices", lambda: ["FM-Piano1 20190916.sf2", "new.sf2"])
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "new.sf2")
+    monkeypatch.setattr(app, "is_playback_available", lambda soundfont_name=None: (True, None))
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+
+    dropdown_update, rerender_update, status_message = app.refresh_soundfont_controls("new.sf2")
+
+    assert dropdown_update["choices"] == ["FM-Piano1 20190916.sf2", "new.sf2"]
+    assert dropdown_update["value"] == "new.sf2"
+    assert rerender_update["interactive"] is True
+    assert status_message == "Found 2 SoundFonts. Selected new.sf2."

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -84,6 +84,54 @@ def test_rerender_current_audio_updates_saved_generation(monkeypatch, tmp_path):
     assert current_audio_path == str(tmp_path / "saved-loop.mp3")
 
 
+def test_load_history_item_warns_when_saved_soundfont_is_missing(monkeypatch, tmp_path):
+    midi_path = _write_binary_file(tmp_path / "loop.mid")
+    audio_path = _write_binary_file(tmp_path / "loop.mp3")
+
+    monkeypatch.setattr(app, "get_soundfont_choices", lambda: ["FM-Piano1 20190916.sf2", "new.sf2"])
+    monkeypatch.setattr(
+        app,
+        "get_default_soundfont",
+        lambda: str(Path("soundfonts") / "FM-Piano1 20190916.sf2"),
+    )
+    monkeypatch.setattr(
+        app,
+        "get_generation",
+        lambda gen_id: SimpleNamespace(
+            midi_path=str(midi_path),
+            audio_path=str(audio_path),
+            soundfont="missing.sf2",
+            id=gen_id,
+        ),
+    )
+    monkeypatch.setattr(app, "MidiFile", lambda path: object())
+    monkeypatch.setattr(app, "visualize_midi_plotly", lambda midi: "viz")
+    monkeypatch.setattr(app, "is_playback_available", lambda soundfont_name=None: (True, None))
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+
+    (
+        loaded_midi_path,
+        loaded_audio_path,
+        dropdown_update,
+        visualization,
+        error_message,
+        generation_id,
+        saved_soundfont,
+        current_audio_path,
+        rerender_update,
+    ) = app.load_history_item("gen_1")
+
+    assert loaded_midi_path == str(midi_path)
+    assert loaded_audio_path == str(audio_path)
+    assert dropdown_update["value"] == "FM-Piano1 20190916.sf2"
+    assert visualization == "viz"
+    assert error_message == "Previously used SoundFont: missing.sf2 (missing)"
+    assert generation_id == "gen_1"
+    assert saved_soundfont == "missing.sf2"
+    assert current_audio_path == str(audio_path)
+    assert rerender_update["interactive"] is True
+
+
 def test_refresh_soundfont_controls_updates_dropdown_choices(monkeypatch):
     midi_path = _write_binary_file(Path("active.mid"))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -85,14 +85,86 @@ def test_rerender_current_audio_updates_saved_generation(monkeypatch, tmp_path):
 
 
 def test_refresh_soundfont_controls_updates_dropdown_choices(monkeypatch):
+    midi_path = _write_binary_file(Path("active.mid"))
+
     monkeypatch.setattr(app, "get_soundfont_choices", lambda: ["FM-Piano1 20190916.sf2", "new.sf2"])
     monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "new.sf2")
     monkeypatch.setattr(app, "is_playback_available", lambda soundfont_name=None: (True, None))
     monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
 
-    dropdown_update, rerender_update, status_message = app.refresh_soundfont_controls("new.sf2")
+    try:
+        dropdown_update, rerender_update, status_message = app.refresh_soundfont_controls(
+            "new.sf2",
+            str(midi_path),
+        )
 
-    assert dropdown_update["choices"] == ["FM-Piano1 20190916.sf2", "new.sf2"]
-    assert dropdown_update["value"] == "new.sf2"
-    assert rerender_update["interactive"] is True
-    assert status_message == "Found 2 SoundFonts. Selected new.sf2."
+        assert dropdown_update["choices"] == ["FM-Piano1 20190916.sf2", "new.sf2"]
+        assert dropdown_update["value"] == "new.sf2"
+        assert rerender_update["interactive"] is True
+        assert status_message == "Found 2 SoundFonts. Selected new.sf2."
+    finally:
+        midi_path.unlink(missing_ok=True)
+
+
+def test_get_rerender_button_update_requires_active_midi(monkeypatch):
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "new.sf2")
+    monkeypatch.setattr(app, "is_playback_available", lambda soundfont_name=None: (True, None))
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+
+    rerender_update = app.get_rerender_button_update("new.sf2", None)
+
+    assert rerender_update["interactive"] is False
+
+
+def test_delete_history_item_disables_rerender_for_deleted_loaded_generation(monkeypatch, tmp_path):
+    midi_path = _write_binary_file(tmp_path / "loop.mid")
+    audio_path = _write_binary_file(tmp_path / "loop.mp3")
+
+    monkeypatch.setattr(app, "delete_generation", lambda gen_id: True)
+    monkeypatch.setattr(app, "get_history_choices", lambda: ["gen_2"])
+    monkeypatch.setattr(app, "render_history_html", lambda: "<div>history</div>")
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "new.sf2")
+    monkeypatch.setattr(app, "is_playback_available", lambda soundfont_name=None: (True, None))
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+
+    (
+        dropdown_update,
+        status_message,
+        history_html,
+        cleared_midi_path,
+        cleared_audio_path,
+        cleared_visualization,
+        current_generation_id,
+        current_saved_soundfont,
+        current_audio_path,
+        rerender_update,
+    ) = app.delete_history_item(
+        "gen_1",
+        current_generation_id="gen_1",
+        soundfont_choice="new.sf2",
+        midi_path=str(midi_path),
+        current_saved_soundfont="old.sf2",
+        current_audio_path=str(audio_path),
+    )
+
+    assert dropdown_update == {"choices": ["gen_2"], "value": None}
+    assert status_message == "Deleted generation"
+    assert history_html == "<div>history</div>"
+    assert cleared_midi_path is None
+    assert cleared_audio_path is None
+    assert cleared_visualization is None
+    assert current_generation_id is None
+    assert current_saved_soundfont is None
+    assert current_audio_path is None
+    assert rerender_update["interactive"] is False
+
+
+def test_refresh_soundfont_controls_stays_disabled_after_active_delete(monkeypatch):
+    monkeypatch.setattr(app, "get_soundfont_choices", lambda: ["FM-Piano1 20190916.sf2", "new.sf2"])
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "new.sf2")
+    monkeypatch.setattr(app, "is_playback_available", lambda soundfont_name=None: (True, None))
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+
+    _, rerender_update, _ = app.refresh_soundfont_controls("new.sf2", None)
+
+    assert rerender_update["interactive"] is False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -106,6 +106,32 @@ def test_refresh_soundfont_controls_updates_dropdown_choices(monkeypatch):
         midi_path.unlink(missing_ok=True)
 
 
+def test_refresh_soundfont_controls_prefers_dependency_status_message(monkeypatch):
+    monkeypatch.setattr(app, "get_soundfont_choices", lambda: ["FM-Piano1 20190916.sf2", "new.sf2"])
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "new.sf2")
+    monkeypatch.setattr(
+        app,
+        "is_playback_available",
+        lambda soundfont_name=None: (False, "FluidSynth is not installed or not in PATH"),
+    )
+    monkeypatch.setattr(
+        app,
+        "get_playback_status_message",
+        lambda soundfont_name=None: "Audio playback is not available. Setup required:\n  - Install FluidSynth: https://github.com/FluidSynth/fluidsynth/releases",
+    )
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+
+    dropdown_update, rerender_update, status_message = app.refresh_soundfont_controls("new.sf2", None)
+
+    assert dropdown_update["choices"] == ["FM-Piano1 20190916.sf2", "new.sf2"]
+    assert dropdown_update["value"] == "new.sf2"
+    assert rerender_update["interactive"] is False
+    assert status_message == (
+        "Audio playback is not available. Setup required:\n"
+        "  - Install FluidSynth: https://github.com/FluidSynth/fluidsynth/releases"
+    )
+
+
 def test_get_rerender_button_update_requires_active_midi(monkeypatch):
     monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "new.sf2")
     monkeypatch.setattr(app, "is_playback_available", lambda soundfont_name=None: (True, None))

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -49,6 +49,19 @@ def test_is_playback_available_reports_missing_requested_soundfont(monkeypatch, 
     assert error == f"Requested SoundFont 'missing.sf2' was not found in '{tmp_path}'."
 
 
+def test_get_playback_status_message_prioritizes_missing_dependencies(monkeypatch):
+    monkeypatch.setattr(audio, "is_playback_available", lambda soundfont_name=None: (False, "dependency error"))
+    monkeypatch.setattr(audio, "is_fluidsynth_available", lambda: False)
+    monkeypatch.setattr(audio, "is_ffmpeg_available", lambda: False)
+    monkeypatch.setattr(audio, "find_soundfont", lambda soundfont_name=None: None)
+
+    status_message = audio.get_playback_status_message("missing.sf2")
+
+    assert "Install FluidSynth" in status_message
+    assert "Install FFmpeg" in status_message
+    assert "Add the requested SoundFont" not in status_message
+
+
 def test_midi_to_mp3_uses_requested_soundfont(monkeypatch, tmp_path):
     midi_path = _write_file(tmp_path / "loop.mid")
     soundfont_path = _write_file(tmp_path / "custom.sf2")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from src import audio
+
+
+def _write_file(path: Path, content: bytes = b"data") -> Path:
+    path.write_bytes(content)
+    return path
+
+
+def test_list_soundfonts_returns_sorted_sf2_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(audio, "SOUNDFONT_DIR", str(tmp_path))
+    _write_file(tmp_path / "zeta.sf2")
+    _write_file(tmp_path / "Alpha.sf2")
+    _write_file(tmp_path / "notes.txt")
+
+    soundfonts = audio.list_soundfonts()
+
+    assert soundfonts == ["Alpha.sf2", "zeta.sf2"]
+
+
+def test_get_default_soundfont_prefers_known_candidates(monkeypatch, tmp_path):
+    monkeypatch.setattr(audio, "SOUNDFONT_DIR", str(tmp_path))
+    _write_file(tmp_path / "custom.sf2")
+    preferred = _write_file(tmp_path / "FM-Piano1 20190916.sf2")
+
+    soundfont_path = audio.get_default_soundfont()
+
+    assert soundfont_path == str(preferred)
+
+
+def test_resolve_soundfont_returns_requested_file_from_soundfont_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(audio, "SOUNDFONT_DIR", str(tmp_path))
+    expected = _write_file(tmp_path / "custom.sf2")
+
+    soundfont_path = audio.resolve_soundfont("custom.sf2")
+
+    assert soundfont_path == str(expected)
+
+
+def test_is_playback_available_reports_missing_requested_soundfont(monkeypatch, tmp_path):
+    monkeypatch.setattr(audio, "SOUNDFONT_DIR", str(tmp_path))
+    monkeypatch.setattr(audio, "is_fluidsynth_available", lambda: True)
+    monkeypatch.setattr(audio, "is_ffmpeg_available", lambda: True)
+
+    available, error = audio.is_playback_available("missing.sf2")
+
+    assert available is False
+    assert error == f"Requested SoundFont 'missing.sf2' was not found in '{tmp_path}'."
+
+
+def test_midi_to_mp3_uses_requested_soundfont(monkeypatch, tmp_path):
+    midi_path = _write_file(tmp_path / "loop.mid")
+    soundfont_path = _write_file(tmp_path / "custom.sf2")
+    output_path = tmp_path / "loop.mp3"
+    captured = {}
+
+    monkeypatch.setattr(audio, "SOUNDFONT_DIR", str(tmp_path))
+    monkeypatch.setattr(audio, "is_playback_available", lambda soundfont_name=None: (True, None))
+
+    class FakeFluidSynth:
+        def __init__(self, selected_soundfont):
+            captured["soundfont_path"] = selected_soundfont
+
+        def midi_to_audio(self, input_midi_path, temp_wav_path):
+            captured["input_midi_path"] = input_midi_path
+            Path(temp_wav_path).write_bytes(b"wav")
+
+    class FakeAudioSegment:
+        @staticmethod
+        def from_wav(temp_wav_path):
+            captured["temp_wav_path"] = temp_wav_path
+
+            class FakeExport:
+                def export(self, target_output_path, format, bitrate):
+                    captured["output_path"] = target_output_path
+                    captured["format"] = format
+                    captured["bitrate"] = bitrate
+                    Path(target_output_path).write_bytes(b"mp3")
+
+            return FakeExport()
+
+    monkeypatch.setattr(audio, "FluidSynth", FakeFluidSynth)
+    monkeypatch.setattr(audio, "AudioSegment", FakeAudioSegment)
+
+    rendered_output = audio.midi_to_mp3(
+        str(midi_path),
+        output_path=str(output_path),
+        soundfont_name="custom.sf2",
+    )
+
+    assert rendered_output == str(output_path)
+    assert captured["soundfont_path"] == str(soundfont_path)
+    assert captured["input_midi_path"] == str(midi_path)
+    assert captured["output_path"] == str(output_path)
+    assert output_path.read_bytes() == b"mp3"

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -91,6 +91,44 @@ def test_save_generation_copies_files_and_persists_metadata(isolated_history_dir
     assert metadata.soundfont == "FM-Piano1 20190916.sf2"
 
 
+def test_update_generation_audio_copies_audio_and_updates_soundfont(
+    isolated_history_dir, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
+
+    midi_source = _write_binary_file(tmp_path / "source.mid")
+    original_audio = _write_binary_file(tmp_path / "source.mp3", b"old-audio")
+    updated_audio = _write_binary_file(tmp_path / "updated.mp3", b"new-audio")
+
+    gen_id = history.save_generation(
+        midi_path=str(midi_source),
+        prompt="warm rhodes loop",
+        key="D",
+        scale="minor",
+        model="gpt-4o-mini",
+        provider="OpenAI",
+        temperature=0.3,
+        cost=1.5,
+        audio_path=str(original_audio),
+        soundfont="old.sf2",
+    )
+
+    updated = history.update_generation_audio(
+        gen_id,
+        str(updated_audio),
+        soundfont="new.sf2",
+    )
+    metadata = history.get_generation(gen_id)
+    gen_dir = isolated_history_dir / "gen_fixed_id"
+
+    assert updated is not None
+    assert updated.audio_path == str(gen_dir / "loop.mp3")
+    assert updated.soundfont == "new.sf2"
+    assert (gen_dir / "loop.mp3").read_bytes() == b"new-audio"
+    assert metadata is not None
+    assert metadata.soundfont == "new.sf2"
+
+
 def test_load_history_allows_older_entries_without_soundfont(isolated_history_dir):
     now = datetime.now()
     _write_generation_metadata(

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -31,6 +31,7 @@ def _write_generation_metadata(
     provider: str = "OpenAI",
     temperature: float = 0.0,
     cost: float | None = None,
+    soundfont: str | None = None,
 ):
     gen_dir = base_dir / f"gen_{gen_id}"
     gen_dir.mkdir(parents=True, exist_ok=True)
@@ -47,6 +48,7 @@ def _write_generation_metadata(
         cost=cost,
         midi_path=str(gen_dir / "loop.mid"),
         audio_path=str(gen_dir / "loop.mp3"),
+        soundfont=soundfont,
     )
     (gen_dir / "metadata.json").write_text(metadata.model_dump_json(indent=2), encoding="utf-8")
     return gen_dir
@@ -68,6 +70,7 @@ def test_save_generation_copies_files_and_persists_metadata(isolated_history_dir
         temperature=0.3,
         cost=1.5,
         audio_path=str(audio_source),
+        soundfont="FM-Piano1 20190916.sf2",
     )
 
     gen_dir = isolated_history_dir / "gen_fixed_id"
@@ -85,6 +88,29 @@ def test_save_generation_copies_files_and_persists_metadata(isolated_history_dir
     assert metadata.provider == "OpenAI"
     assert metadata.temperature == 0.3
     assert metadata.cost == 1.5
+    assert metadata.soundfont == "FM-Piano1 20190916.sf2"
+
+
+def test_load_history_allows_older_entries_without_soundfont(isolated_history_dir):
+    now = datetime.now()
+    _write_generation_metadata(
+        isolated_history_dir,
+        gen_id="older",
+        timestamp=now - timedelta(days=1),
+        soundfont=None,
+    )
+    _write_generation_metadata(
+        isolated_history_dir,
+        gen_id="newer",
+        timestamp=now,
+        soundfont="FM-Piano1 20190916.sf2",
+    )
+
+    loaded = history.load_history()
+
+    assert [entry.id for entry in loaded] == ["newer", "older"]
+    assert loaded[0].soundfont == "FM-Piano1 20190916.sf2"
+    assert loaded[1].soundfont is None
 
 
 def test_load_history_sorts_newest_first(isolated_history_dir):


### PR DESCRIPTION
## Summary

This branch adds a bundled default SoundFont, exposes SoundFont selection in the Gradio UI, and introduces an explicit rerender action for the currently loaded MIDI. It also preserves the SoundFont used for each saved generation so history entries can reload quickly and the app can decide whether the rendered audio already matches the current selection.

The follow-up fixes make the playback/status flow more precise by clearing stale rerender state after deletion, suppressing conflicting SoundFont status text when playback prerequisites are missing, and warning when a loaded history item references a SoundFont that is no longer installed locally.

## What Changed

The audio stack now treats SoundFont selection as a first-class input instead of auto-picking an arbitrary `.sf2` file. The app surfaces the available SoundFonts in the UI, uses the selected file when generating or rerendering audio, and keeps the saved generation metadata aligned with the audio that was actually rendered.

History loads stay fast because existing MP3s are still reused immediately when available. When the user wants a different SoundFont, rerendering happens only on demand instead of automatically on dropdown changes.

## Why

The repo previously discovered SoundFonts implicitly and could render audio only through that hidden selection. That made playback behavior harder to reason about, made history reloads opaque, and prevented users from explicitly switching SoundFonts while keeping the rest of a generation intact.

Bundling a small CC0 SoundFont also removes the need for a separate first-run download step, so a fresh clone can render audio as long as FluidSynth and FFmpeg are installed.

## Validation

Focused tests were added or updated for the audio selection path, generation metadata, and app state transitions. The intended verification for this branch is:

- `pytest tests/test_audio.py`
- `pytest tests/test_history.py`
- `pytest tests/test_app.py`
- `python app.py` for a manual Gradio smoke test

The manual smoke test should cover generating a loop, switching SoundFonts, loading a prior history item, and triggering an explicit rerender.

## Risks and Follow-Ups

The bundled SoundFont is a larger binary asset, so repo size and distribution packaging should be watched if the project later ships as a wheel or source distribution. The missing-SoundFont warning is intentionally conservative: playback uses an installed font, but the saved metadata remains visible for transparency.