### PR TITLE
Add Claude Fable 5 model support

### DIFF
--- a/model_list.json
+++ b/model_list.json
@@ -277,6 +277,23 @@
             }
         },
         "Anthropic": {
+            "claude-fable-5": {
+                "extended_thinking": true,
+                "effort_options": ["low", "medium", "high", "xhigh", "max"],
+                "max_tokens": 128000,
+                "cost": {
+                    "input": 10.00,
+                    "5m cache input": 12.50,
+                    "1h cache input": 20.00,
+                    "cache hits/refreshes": 1.00,
+                    "output": 50.00
+                },
+                "rate_limits": {
+                    "RPM": 50,
+                    "ITPM": 100000,
+                    "OTPM": 20000
+                }
+            },
             "claude-opus-4-8":{
                 "extended_thinking": true,
                 "effort_options": ["low", "medium", "high", "xhigh", "max"],

--- a/src/claude_api.py
+++ b/src/claude_api.py
@@ -9,6 +9,8 @@ import os
 logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+ALWAYS_ON_ADAPTIVE_THINKING_MODELS = {"claude-fable-5", "claude-mythos-5"}
+
 def initialize_anthropic_client():
     """
     Initializes and returns an Anthropic client using API key from the .env file.
@@ -116,26 +118,30 @@ def loop_gen(prompt, model, temp=0.0, use_thinking=False, effort="low"):
     
     # Prepare API call parameters
     model_info = utils.get_model_info()
+    model_config = model_info["models"]["Anthropic"][model]
+    always_on_adaptive_thinking = model in ALWAYS_ON_ADAPTIVE_THINKING_MODELS
     api_params = {
         "model": model,
-        "max_tokens": model_info["models"]["Anthropic"][model]["max_tokens"],
+        "max_tokens": model_config["max_tokens"],
         "system": [{"type": "text", "text": loop_prompt, "cache_control": {"type": "ephemeral"}}],
-        "temperature": temp,
         "messages": [{"role": "user", "content": prompt}],
         "tools": tools,
         "tool_choice": {"type": "tool", "name": "build_MIDI_loop"},
         "stream": True
     }
+    if not always_on_adaptive_thinking:
+        api_params["temperature"] = temp
     
     # Add thinking configuration
-    model_config = model_info["models"]["Anthropic"][model]
-    # Auto-enable adaptive thinking for models with effort_options (e.g., 4-6 models)
+    # Auto-enable adaptive thinking for models with effort_options when it is not always on.
     # Thinking requires tool_choice "auto" (forced tool use not allowed)
     if model_config.get("effort_options"):
         api_params["tool_choice"] = {"type": "auto"}
-        api_params["thinking"] = {"type": "adaptive"}
+        if not always_on_adaptive_thinking:
+            api_params["thinking"] = {"type": "adaptive"}
         api_params["output_config"] = {"effort": effort}
-        api_params["temperature"] = 1.0
+        if not always_on_adaptive_thinking:
+            api_params["temperature"] = 1.0
     # Legacy extended thinking requires explicit opt-in and auto tool_choice
     elif use_thinking and model_config.get("extended_thinking"):
         api_params["tool_choice"] = {"type": "auto"}


### PR DESCRIPTION
## Summary
- Added `claude-fable-5` to the Anthropic model registry with cost, rate limit, token, and effort metadata.
- Updated Claude routing to treat always-on adaptive thinking models separately from legacy thinking behavior.
- Prevented redundant `temperature` and `thinking` settings for models where adaptive thinking is always enabled.

## Testing
- pytest - 82 passed, 2 warnings
- Reviewed the diff for `model_list.json` and `src/claude_api.py` to confirm the new model is wired into the Anthropic path.
- Local app testing
  - Generated multiple loops with various reasoning effort levels selected using `claude-fable-5`.
  - Verified the new logic preserves legacy behavior for non-`claude-fable-5` models.