### PR TITLE
Fix `midi_to_note_name` for plain Python lists

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -305,8 +305,7 @@ def midi_to_note_name(midi_numbers):
     Returns:
         midi_names (list[str]): A list of note names corresponding to the MIDI numbers.
     """
-    octave = midi_numbers // 12 - 1
-    return [f"{pitch_class_to_note(n)}{oct}" for n, oct in zip(midi_numbers, octave)]
+    return [f"{pitch_class_to_note(n)}{n // 12 - 1}" for n in midi_numbers]
 
 
 def save_messages_to_json(messages, filename):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,6 +158,10 @@ def test_midi_number_to_name_and_octave_returns_canonical_name_and_octave(
     assert octave == expected_octave
 
 
+def test_midi_to_note_name_accepts_plain_python_lists():
+    assert utils.midi_to_note_name([60, 61, 73]) == ["C4", "C#4", "C#5"]
+
+
 def test_sixteenth_converters_round_trip_enum_values():
     sixteenth_note = utils.int_to_sixteenth_g(16)
 


### PR DESCRIPTION
## Summary
- Fix `midi_to_note_name` so it works with standard Python lists instead of assuming vectorized arithmetic.
- Simplify octave calculation directly inside the list comprehension.
- Add coverage for plain list input in `tests/test_utils.py`.

## Testing
- Added a unit test asserting `[60, 61, 73] -> ["C4", "C#4", "C#5"]`.
- `python -m pytest`: 83 passed, 2 warnings

## Notes
This PR is an alternate solution approach to #31 