### PR TITLE
Accept Python lists in MIDI note name conversion

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -305,6 +305,7 @@ def midi_to_note_name(midi_numbers):
     Returns:
         midi_names (list[str]): A list of note names corresponding to the MIDI numbers.
     """
+    midi_numbers = np.asarray(midi_numbers)
     octave = midi_numbers // 12 - 1
     return [f"{pitch_class_to_note(n)}{oct}" for n, oct in zip(midi_numbers, octave)]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,6 +158,10 @@ def test_midi_number_to_name_and_octave_returns_canonical_name_and_octave(
     assert octave == expected_octave
 
 
+def test_midi_to_note_name_accepts_plain_python_lists():
+    assert utils.midi_to_note_name([60, 61, 72]) == ["C4", "C#4", "C5"]
+
+
 def test_sixteenth_converters_round_trip_enum_values():
     sixteenth_note = utils.int_to_sixteenth_g(16)
 


### PR DESCRIPTION
## Summary
- Normalize `midi_to_note_name` input with `np.asarray(...)` so it accepts plain Python lists as well as NumPy arrays.
- Add a regression test covering list input and expected note-name output.

## Testing
- `python -m pytest`: 83 passed, 2 warnings
- Covered by `tests/test_utils.py::test_midi_to_note_name_accepts_plain_python_lists`.

## Notes
This PR is an alternate solution approach to #30 