### PR TITLE
Harden provider response parsing

### DIFF
--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -78,13 +78,25 @@ def calc_cost(model, usage):
 def process_output(response):
     final_result = ""
     thinking_content = ""
-    for part in response.candidates[0].content.parts:
-        if not part.text:
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        raise ValueError("Google response did not include any candidates.")
+
+    content = getattr(candidates[0], "content", None)
+    parts = getattr(content, "parts", None) or []
+    if not parts:
+        raise ValueError("Google response did not include generated content parts.")
+
+    for part in parts:
+        text = getattr(part, "text", None)
+        if not text:
             continue
-        if part.thought:
-            thinking_content += part.text
+        if getattr(part, "thought", False):
+            thinking_content += text
         else:
-            final_result += part.text
+            final_result += text
+    if not final_result:
+        raise ValueError("Google response did not include final loop content.")
     return final_result, thinking_content
 
 
@@ -134,7 +146,9 @@ def loop_gen(prompt, model, temp=0.0, use_thinking=None, effort=None):
         config=config
     )  
     content, thinking_content = process_output(response)
-    midi_loop: objects.Loop_G = response.parsed  
+    midi_loop: objects.Loop_G = response.parsed
+    if midi_loop is None:
+        raise ValueError("Google response did not include parsed loop content.")
     # Format into a message history for training and debugging purposes
     messages = [
         {"role": "system", "content": loop_prompt},

--- a/src/ollama_api.py
+++ b/src/ollama_api.py
@@ -107,13 +107,15 @@ def loop_gen(prompt, model, temp=0.0):
         }
     )
     # Extract the generated MIDI loop
-    if completion.message.content:
-        midi_loop = objects.Loop.model_validate_json(completion.message.content)
-    else:
-        print("No content returned from the model")
-        midi_loop = None
-    if completion.message.thinking:
-        messages.append({"role": "assistant", "content": completion.message.thinking})
+    message = getattr(completion, "message", None)
+    content = getattr(message, "content", None)
+    if not content:
+        raise ValueError("Ollama response did not include generated content.")
+
+    midi_loop = objects.Loop.model_validate_json(content)
+    thinking = getattr(message, "thinking", None)
+    if thinking:
+        messages.append({"role": "assistant", "content": thinking})
     messages.append({"role": "assistant", "content": str(midi_loop)})
     # Save messages for debugging/training purposes
     utils.save_messages_to_json(messages, filename="loop")

--- a/src/openai_api.py
+++ b/src/openai_api.py
@@ -65,9 +65,11 @@ def calc_price(model, response):
 def extract_reasoning(response):
     reasoning = ""
     for item in getattr(response, "output", []):
-        if item.type == "reasoning":
-            for s in item.summary:
-                reasoning += s.text + "\n"
+        if getattr(item, "type", None) == "reasoning":
+            for summary in getattr(item, "summary", []) or []:
+                text = getattr(summary, "text", None)
+                if text:
+                    reasoning += text + "\n"
     return reasoning
 
 def loop_gen(prompt, model, temp=0.0, effort=None):
@@ -121,6 +123,9 @@ def loop_gen(prompt, model, temp=0.0, effort=None):
     except APIError as e:
         logger.error(f"OpenAI API error: {e}")
         raise
+
+    if response.output_parsed is None:
+        raise ValueError("OpenAI response did not include parsed loop content.")
 
     reasoning = extract_reasoning(response)
     if reasoning:

--- a/tests/test_provider_response_parsing.py
+++ b/tests/test_provider_response_parsing.py
@@ -1,0 +1,68 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src import gemini_api, objects, ollama_api, openai_api
+
+
+def _loop_payload():
+    bar = {
+        "num": 1,
+        "notes": [
+            {
+                "pitch": "C",
+                "octave": 4,
+                "velocity": 100,
+                "time": {"start_beat": 1, "duration": 1},
+            }
+        ],
+    }
+    return {"Bar_1": bar, "Bar_2": {**bar, "num": 2}, "Bar_3": {**bar, "num": 3}, "Bar_4": {**bar, "num": 4}}
+
+
+def test_openai_extract_reasoning_ignores_missing_summary():
+    response = SimpleNamespace(output=[SimpleNamespace(type="reasoning")])
+
+    assert openai_api.extract_reasoning(response) == ""
+
+
+def test_gemini_process_output_rejects_empty_candidates():
+    response = SimpleNamespace(candidates=[])
+
+    with pytest.raises(ValueError, match="Google response did not include any candidates"):
+        gemini_api.process_output(response)
+
+
+def test_gemini_process_output_rejects_missing_parts():
+    response = SimpleNamespace(candidates=[SimpleNamespace(content=SimpleNamespace(parts=[]))])
+
+    with pytest.raises(ValueError, match="Google response did not include generated content parts"):
+        gemini_api.process_output(response)
+
+
+def test_ollama_loop_gen_accepts_missing_thinking(monkeypatch):
+    payload = json.dumps(_loop_payload())
+    completion = SimpleNamespace(message=SimpleNamespace(content=payload))
+    fake_client = SimpleNamespace(chat=lambda **kwargs: completion)
+
+    monkeypatch.setattr(ollama_api, "initialize_ollama_client", lambda: fake_client)
+    monkeypatch.setattr(ollama_api.utils, "get_loop_prompt", lambda: "system prompt")
+    monkeypatch.setattr(ollama_api.utils, "save_messages_to_json", lambda *args, **kwargs: None)
+
+    midi_loop, messages, cost = ollama_api.loop_gen("write a loop", "llama3")
+
+    assert isinstance(midi_loop, objects.Loop)
+    assert messages[-1]["content"] == str(midi_loop)
+    assert cost == 0
+
+
+def test_ollama_loop_gen_rejects_missing_content(monkeypatch):
+    completion = SimpleNamespace(message=SimpleNamespace())
+    fake_client = SimpleNamespace(chat=lambda **kwargs: completion)
+
+    monkeypatch.setattr(ollama_api, "initialize_ollama_client", lambda: fake_client)
+    monkeypatch.setattr(ollama_api.utils, "get_loop_prompt", lambda: "system prompt")
+
+    with pytest.raises(ValueError, match="Ollama response did not include generated content"):
+        ollama_api.loop_gen("write a loop", "llama3")


### PR DESCRIPTION
## Summary
- Hardened Gemini, Ollama, and OpenAI response handling against missing or partial provider fields.
- Added explicit `ValueError` failures when final parsed loop content or generated content is absent.
- Expanded test coverage for empty candidates, missing content parts, missing Ollama content, and missing OpenAI reasoning summaries.

## Testing
- `pytest tests/test_provider_response_parsing.py`: 5 passed
- `python -m pytest`: 91 passed, 2 warnings

Fixes Issue #29 