### PR TITLE
Guard direct evaluator cloud run

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -30,6 +30,19 @@ results = evaluator.evaluate(
 )
 ```
 
+### Direct Script Safeguard
+
+Running `python evaluation/evaluator.py` directly is guarded because the
+example in that file starts a broad cloud evaluation across multiple paid
+providers. The script prints a warning and requires the exact confirmation
+phrase `RUN CLOUD EVALUATION` before it creates an `Evaluator` or starts any
+provider calls.
+
+Pressing Enter, sending no input, or typing anything else aborts the script
+without creating evaluation outputs. For smaller intentional runs, prefer the
+Python API examples above so you can choose the prompts, roots, models, and run
+name explicitly.
+
 ### Launch the Dashboard
 
 ```bash

--- a/evaluation/evaluator.py
+++ b/evaluation/evaluator.py
@@ -31,6 +31,35 @@ from src.utils import DURATION_KEYWORDS
 from src.midi_processing import loop_to_midi
 from evaluation.tests import scale_test, duration_test
 
+DIRECT_EVALUATION_CONFIRMATION = "RUN CLOUD EVALUATION"
+
+
+def confirm_direct_evaluation(input_func=input) -> bool:
+    """
+    Confirm before running the expensive direct-execution evaluation.
+
+    Returns:
+        bool: True when the exact confirmation phrase is entered.
+    """
+    print(
+        "WARNING: This direct evaluator run starts a broad cloud evaluation "
+        "across multiple paid providers."
+    )
+    print("It may be slow and may incur API costs.")
+    try:
+        response = input_func(
+            f"Type {DIRECT_EVALUATION_CONFIRMATION!r} to continue: "
+        )
+    except EOFError:
+        response = ""
+
+    if response != DIRECT_EVALUATION_CONFIRMATION:
+        print("Aborted. No evaluator was created and no provider calls were made.")
+        return False
+
+    return True
+
+
 class Evaluator:
     """
     Unified evaluation framework for testing MIDI loop generation across models.
@@ -973,6 +1002,9 @@ class Evaluator:
 
 
 if __name__ == "__main__":
+
+    if not confirm_direct_evaluation():
+        raise SystemExit(0)
 
     eval = Evaluator(output_dir="runs",temperature=0.0)
     eval.evaluate(

--- a/evaluation/evaluator.py
+++ b/evaluation/evaluator.py
@@ -1004,7 +1004,7 @@ class Evaluator:
 if __name__ == "__main__":
 
     if not confirm_direct_evaluation():
-        raise SystemExit(0)
+        raise SystemExit(1)
 
     eval = Evaluator(output_dir="runs",temperature=0.0)
     eval.evaluate(

--- a/tests/test_evaluator_direct_run_guard.py
+++ b/tests/test_evaluator_direct_run_guard.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import runpy
+
+import pytest
+
+
+def test_direct_evaluator_run_aborts_before_creating_outputs(
+    monkeypatch, tmp_path
+):
+    evaluator_path = (
+        Path(__file__).resolve().parents[1] / "evaluation" / "evaluator.py"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(evaluator_path), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    assert not (tmp_path / "runs" / "run.log").exists()
+
+
+def test_direct_evaluation_confirmation_requires_exact_phrase():
+    from evaluation.evaluator import (
+        DIRECT_EVALUATION_CONFIRMATION,
+        confirm_direct_evaluation,
+    )
+
+    assert confirm_direct_evaluation(lambda _prompt: "y") is False
+    assert (
+        confirm_direct_evaluation(
+            lambda _prompt: DIRECT_EVALUATION_CONFIRMATION
+        )
+        is True
+    )

--- a/tests/test_evaluator_direct_run_guard.py
+++ b/tests/test_evaluator_direct_run_guard.py
@@ -17,7 +17,7 @@ def test_direct_evaluator_run_aborts_before_creating_outputs(
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_path(str(evaluator_path), run_name="__main__")
 
-    assert exc_info.value.code == 0
+    assert exc_info.value.code == 1
     assert not (tmp_path / "runs" / "run.log").exists()
 
 
@@ -34,3 +34,12 @@ def test_direct_evaluation_confirmation_requires_exact_phrase():
         )
         is True
     )
+
+
+def test_direct_evaluation_confirmation_handles_closed_stdin():
+    from evaluation.evaluator import confirm_direct_evaluation
+
+    def raise_eof(_prompt):
+        raise EOFError
+
+    assert confirm_direct_evaluation(raise_eof) is False


### PR DESCRIPTION
## Summary

- Adds an exact confirmation gate before the direct `evaluation/evaluator.py` cloud evaluation can run.
- Keeps the existing direct-run setup intact, but aborts before creating `Evaluator` unless the user types `RUN CLOUD EVALUATION`.
- Documents the safeguard and adds focused pytest coverage for the abort path.

Closes #17.

## Validation

- `'' | python evaluation\evaluator.py`
- `Test-Path runs\run.log` returned `False`
- `$env:PYTHONPATH=(Get-Location).Path; pytest tests\test_bootstrap.py tests\test_runs.py tests\test_evaluator_direct_run_guard.py`

## Notes

The confirmation happens before `Evaluator(output_dir="runs", temperature=0.0)`, so accidental direct execution does not create `runs/run.log` or start provider-backed work.
