### PR TITLE
Fix Gemini cache storage cost overcounting

### DIFF
--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -11,6 +11,22 @@ import sys
 logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+PRICE_PER_MILLION_TOKENS = 1000000
+# Gemini implicit cache storage is reported as roughly 5-6 minutes.
+IMPLICIT_CACHE_STORAGE_TTL_HOURS = 0.1
+
+
+def _cache_storage_cost(cached_tokens, storage_hour_price):
+    """Estimate Gemini implicit cache storage from cached tokens and assumed TTL."""
+    if not cached_tokens or not storage_hour_price:
+        return 0
+    return (
+        cached_tokens
+        * (storage_hour_price / PRICE_PER_MILLION_TOKENS)
+        * IMPLICIT_CACHE_STORAGE_TTL_HOURS
+    )
+
+
 def initialize_gemini_client():
     """Initializes and returns a Gemini client using API key from the .env file or the default key.
     
@@ -41,37 +57,33 @@ def calc_cost(model, usage):
     """
     model_info = utils.get_model_info()
     model_cost = model_info["models"]["Google"][model]["cost"]
-    cached = usage.cached_content_token_count or 0
+    prompt_tokens = usage.prompt_token_count or 0
+    cached = min(usage.cached_content_token_count or 0, prompt_tokens)
 
     # Models with tiered pricing switch rates once the prompt exceeds 200k tokens.
     if isinstance(model_cost["input"], dict):
-        if usage.prompt_token_count <= 200000:
-            input_cost = model_cost["input"]["<=200k"] / 1000000
-            output_cost = model_cost["output"]["<=200k"] / 1000000
-            cache_cost = model_cost["cache"]["<=200k"] / 1000000
+        if prompt_tokens <= 200000:
+            input_cost = model_cost["input"]["<=200k"] / PRICE_PER_MILLION_TOKENS
+            output_cost = model_cost["output"]["<=200k"] / PRICE_PER_MILLION_TOKENS
+            cache_cost = model_cost["cache"]["<=200k"] / PRICE_PER_MILLION_TOKENS
         else:
-            input_cost = model_cost["input"][">200k"] / 1000000
-            output_cost = model_cost["output"][">200k"] / 1000000
-            cache_cost = model_cost["cache"][">200k"] / 1000000
-        # Implicit caching storage is reported 5-6 minutes, so we can estimate storage cost per api call
-        storage_cost = model_cost["cache"]["storage hour"] * 0.1 if cached else 0
+            input_cost = model_cost["input"][">200k"] / PRICE_PER_MILLION_TOKENS
+            output_cost = model_cost["output"][">200k"] / PRICE_PER_MILLION_TOKENS
+            cache_cost = model_cost["cache"][">200k"] / PRICE_PER_MILLION_TOKENS
+        storage_cost = _cache_storage_cost(cached, model_cost["cache"]["storage hour"])
     else:
         # For other models, use the default cost structure
-        input_cost = model_cost["input"] / 1000000
-        output_cost = model_cost["output"] / 1000000
+        input_cost = model_cost["input"] / PRICE_PER_MILLION_TOKENS
+        output_cost = model_cost["output"] / PRICE_PER_MILLION_TOKENS
         # Check if cache cost is defined for the model
         if "cache" in model_cost:
-            cache_cost = model_cost["cache"]["text"] / 1000000
-            # Implicit caching storage is reported 5-6 minutes, so we can estimate storage cost per api call
-            storage_cost = model_cost["cache"]["storage hour"] * 0.1 if cached else 0
+            cache_cost = model_cost["cache"]["text"] / PRICE_PER_MILLION_TOKENS
+            storage_cost = _cache_storage_cost(cached, model_cost["cache"]["storage hour"])
         else:
             cache_cost = 0
             storage_cost = 0
     # Gemini doesn't subtract cached tokens from prompt tokens, so we need to do that here
-    if cached:
-        new_input_tokens = usage.prompt_token_count - cached
-    else:
-        new_input_tokens = usage.prompt_token_count
+    new_input_tokens = max(prompt_tokens - cached, 0)
     # Calculate total cost
     return (new_input_tokens * input_cost) + (usage.candidates_token_count * output_cost) + (cached * cache_cost) + storage_cost
 

--- a/tests/test_gemini_api.py
+++ b/tests/test_gemini_api.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src import gemini_api
+
+
+def _stub_model_info():
+    return {
+        "models": {
+            "Google": {
+                "tiered-model": {
+                    "cost": {
+                        "input": {"<=200k": 2.00, ">200k": 4.00},
+                        "cache": {"<=200k": 0.20, ">200k": 0.40, "storage hour": 4.50},
+                        "output": {"<=200k": 12.00, ">200k": 18.00},
+                    }
+                },
+                "flat-model": {
+                    "cost": {
+                        "input": 0.30,
+                        "cache": {"text": 0.03, "storage hour": 1.00},
+                        "output": 2.50,
+                    }
+                },
+            }
+        }
+    }
+
+
+@pytest.fixture
+def stub_model_info(monkeypatch):
+    monkeypatch.setattr(gemini_api.utils, "get_model_info", _stub_model_info)
+
+
+def test_calc_cost_scales_tiered_cache_storage_by_cached_tokens(stub_model_info):
+    usage = SimpleNamespace(
+        prompt_token_count=10000,
+        candidates_token_count=1000,
+        cached_content_token_count=5000,
+    )
+
+    cost = gemini_api.calc_cost("tiered-model", usage)
+
+    expected = (
+        (5000 * (2.00 / 1_000_000))
+        + (1000 * (12.00 / 1_000_000))
+        + (5000 * (0.20 / 1_000_000))
+        + (5000 * (4.50 / 1_000_000) * gemini_api.IMPLICIT_CACHE_STORAGE_TTL_HOURS)
+    )
+    assert cost == pytest.approx(expected)
+
+
+def test_calc_cost_scales_flat_cache_storage_by_cached_tokens(stub_model_info):
+    usage = SimpleNamespace(
+        prompt_token_count=20000,
+        candidates_token_count=400,
+        cached_content_token_count=12000,
+    )
+
+    cost = gemini_api.calc_cost("flat-model", usage)
+
+    expected = (
+        (8000 * (0.30 / 1_000_000))
+        + (400 * (2.50 / 1_000_000))
+        + (12000 * (0.03 / 1_000_000))
+        + (12000 * (1.00 / 1_000_000) * gemini_api.IMPLICIT_CACHE_STORAGE_TTL_HOURS)
+    )
+    assert cost == pytest.approx(expected)
+
+
+def test_calc_cost_caps_cached_tokens_at_prompt_tokens(stub_model_info):
+    usage = SimpleNamespace(
+        prompt_token_count=1000,
+        candidates_token_count=10,
+        cached_content_token_count=1500,
+    )
+
+    cost = gemini_api.calc_cost("tiered-model", usage)
+
+    expected = (
+        (10 * (12.00 / 1_000_000))
+        + (1000 * (0.20 / 1_000_000))
+        + (1000 * (4.50 / 1_000_000) * gemini_api.IMPLICIT_CACHE_STORAGE_TTL_HOURS)
+    )
+    assert cost == pytest.approx(expected)
+    assert cost >= 0


### PR DESCRIPTION
## Summary
- Fixes #16 by scaling Gemini cache storage estimates by cached token count, storage-hour price, and the documented implicit-cache TTL assumption.
- Caps cached token usage at prompt token usage so uncached input cost cannot go negative when provider metadata reports more cached tokens than prompt tokens.
- Adds focused regression coverage for tiered Gemini pricing, flat Gemini pricing, and the cached-token cap.

## Testing
- `python -m pytest tests/test_gemini_api.py` - all 3 tests reached 100%, but the process timed out during shutdown.
- `python -m pytest tests/test_provider_response_parsing.py` - all 5 tests reached 100%, but the process timed out during shutdown.
- Direct cost check for `gemini-3.1-pro-preview` with 10,000 prompt tokens, 1,000 output tokens, and 5,000 cached tokens returned `0.02525000`.
- Direct cap check with 1,000 prompt tokens and 1,500 cached tokens returned non-negative cost `0.00077000`.

## Notes
- Follow-up: evaluate explicit Gemini caching for stable prompt prefixes, using the lowest practical TTL. This branch only fixes cost estimation math and does not change Gemini request behavior.
