### PR TITLE
Use reported cache usage for provider cost accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ The pytest suite is intentionally local and hermetic:
 5. **Inspect JSON logs**  
    - `loop.json` records the full message exchange and reasoning
 
+## Cost and Prompt Caching
+
+LoopGPT estimates provider costs from the token usage fields returned by each API. Prompt-cache savings, when a provider reports them, are included in those estimates.
+
+Normal LoopGPT generations should not be expected to benefit much from prompt caching. The reusable system prompt is relatively short, and each request includes a variable user prompt, so typical requests are below many provider cache thresholds. Avoid padding prompts solely to force cache eligibility; it adds cost and can make generations less predictable.
+
 ## Evaluation Framework
 
 The evaluation framework lives in the `evaluation/` directory and is documented separately in [`evaluation/README.md`](evaluation/README.md).

--- a/src/claude_api.py
+++ b/src/claude_api.py
@@ -10,6 +10,7 @@ logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(asctime)s -
 logger = logging.getLogger(__name__)
 
 ALWAYS_ON_ADAPTIVE_THINKING_MODELS = {"claude-fable-5", "claude-mythos-5"}
+ANTHROPIC_CACHE_CONTROL_MIN_CHARS = 4096
 
 def initialize_anthropic_client():
     """
@@ -50,6 +51,14 @@ def calc_price(model, output):
                     
         total_price = (output["input_tokens"] * input_cost) + (output["output_tokens"] * output_cost) + (output["cache_creation"] * cached_5min) + (output["cache_read"] * cache_hits)
         return total_price
+
+
+def build_system_prompt_block(loop_prompt):
+    """Build Anthropic's system text block, marking only likely-cacheable prompts."""
+    block = {"type": "text", "text": loop_prompt}
+    if len(loop_prompt) >= ANTHROPIC_CACHE_CONTROL_MIN_CHARS:
+        block["cache_control"] = {"type": "ephemeral"}
+    return block
 
 def process_streaming_response(completion):
     # Extract text, tool JSON, and token usage from the streaming response.
@@ -123,7 +132,7 @@ def loop_gen(prompt, model, temp=0.0, use_thinking=False, effort="low"):
     api_params = {
         "model": model,
         "max_tokens": model_config["max_tokens"],
-        "system": [{"type": "text", "text": loop_prompt, "cache_control": {"type": "ephemeral"}}],
+        "system": [build_system_prompt_block(loop_prompt)],
         "messages": [{"role": "user", "content": prompt}],
         "tools": tools,
         "tool_choice": {"type": "tool", "name": "build_MIDI_loop"},

--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -63,9 +63,10 @@ def calc_cost(model, usage):
         else:
             cache_cost = 0
     # Gemini reports cached tokens separately but leaves them in prompt tokens.
-    # Only charge non-cached prompt tokens at the standard input rate, and guard
-    # against malformed usage payloads that report more cached tokens than input.
-    new_input_tokens = max((usage.prompt_token_count or 0) - cached, 0)
+    new_input_tokens, cached = utils.split_reported_cache_tokens(
+        usage.prompt_token_count,
+        cached,
+    )
     # Calculate total cost
     return (new_input_tokens * input_cost) + (usage.candidates_token_count * output_cost) + (cached * cache_cost)
 

--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -53,8 +53,6 @@ def calc_cost(model, usage):
             input_cost = model_cost["input"][">200k"] / 1000000
             output_cost = model_cost["output"][">200k"] / 1000000
             cache_cost = model_cost["cache"][">200k"] / 1000000
-        # Implicit caching storage is reported 5-6 minutes, so we can estimate storage cost per api call
-        storage_cost = model_cost["cache"]["storage hour"] * 0.1 if cached else 0
     else:
         # For other models, use the default cost structure
         input_cost = model_cost["input"] / 1000000
@@ -62,18 +60,14 @@ def calc_cost(model, usage):
         # Check if cache cost is defined for the model
         if "cache" in model_cost:
             cache_cost = model_cost["cache"]["text"] / 1000000
-            # Implicit caching storage is reported 5-6 minutes, so we can estimate storage cost per api call
-            storage_cost = model_cost["cache"]["storage hour"] * 0.1 if cached else 0
         else:
             cache_cost = 0
-            storage_cost = 0
-    # Gemini doesn't subtract cached tokens from prompt tokens, so we need to do that here
-    if cached:
-        new_input_tokens = usage.prompt_token_count - cached
-    else:
-        new_input_tokens = usage.prompt_token_count
+    # Gemini reports cached tokens separately but leaves them in prompt tokens.
+    # Only charge non-cached prompt tokens at the standard input rate, and guard
+    # against malformed usage payloads that report more cached tokens than input.
+    new_input_tokens = max((usage.prompt_token_count or 0) - cached, 0)
     # Calculate total cost
-    return (new_input_tokens * input_cost) + (usage.candidates_token_count * output_cost) + (cached * cache_cost) + storage_cost
+    return (new_input_tokens * input_cost) + (usage.candidates_token_count * output_cost) + (cached * cache_cost)
 
 def process_output(response):
     final_result = ""

--- a/src/openai_api.py
+++ b/src/openai_api.py
@@ -53,8 +53,10 @@ def calc_price(model, response):
 
     # Determine cached tokens if available (Responses API structure)
     if (hasattr(usage, "input_tokens_details") and usage.input_tokens_details and hasattr(usage.input_tokens_details, "cached_tokens")):
-        cached_tokens = usage.input_tokens_details.cached_tokens or 0
-        new_input_tokens = usage.input_tokens - cached_tokens
+        new_input_tokens, cached_tokens = utils.split_reported_cache_tokens(
+            usage.input_tokens,
+            usage.input_tokens_details.cached_tokens,
+        )
     else:
         new_input_tokens = usage.input_tokens
         cached_tokens = 0

--- a/src/utils.py
+++ b/src/utils.py
@@ -104,6 +104,19 @@ def get_loop_prompt():
     with open(os.path.join("Prompts", "loop gen.txt"), "r") as prompt_file:
         return prompt_file.read()
 
+
+def split_reported_cache_tokens(total_tokens, cached_tokens):
+    """Return uncached and cached token counts from provider-reported usage.
+
+    Cache savings should come from actual provider usage fields, not estimated
+    cache behavior. Malformed negative values are ignored, and cached tokens are
+    capped to the reported total so input-token costs cannot go negative.
+    """
+    total = max(total_tokens or 0, 0)
+    cached = min(max(cached_tokens or 0, 0), total)
+    return total - cached, cached
+
+
 def pitch_class_to_note(pc):
     """Convert a pitch class integer (0-11) to a note name.
 

--- a/tests/test_gemini_api.py
+++ b/tests/test_gemini_api.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src import gemini_api
+
+
+def test_calc_cost_uses_reported_cached_tokens_without_storage_estimate():
+    usage = SimpleNamespace(
+        prompt_token_count=1000,
+        candidates_token_count=200,
+        cached_content_token_count=400,
+    )
+
+    cost = gemini_api.calc_cost("gemini-2.5-pro", usage)
+
+    expected = (600 * 1.25 / 1_000_000) + (200 * 10.00 / 1_000_000) + (400 * 0.125 / 1_000_000)
+    assert cost == pytest.approx(expected)
+
+
+def test_calc_cost_clamps_cached_tokens_to_avoid_negative_input_cost():
+    usage = SimpleNamespace(
+        prompt_token_count=100,
+        candidates_token_count=0,
+        cached_content_token_count=150,
+    )
+
+    cost = gemini_api.calc_cost("gemini-2.5-pro", usage)
+
+    assert cost == pytest.approx(150 * 0.125 / 1_000_000)
+
+
+def test_calc_cost_handles_models_without_cache_pricing():
+    usage = SimpleNamespace(
+        prompt_token_count=1000,
+        candidates_token_count=200,
+        cached_content_token_count=None,
+    )
+
+    cost = gemini_api.calc_cost("gemini-2.0-flash-lite", usage)
+
+    expected = (1000 * 0.075 / 1_000_000) + (200 * 0.30 / 1_000_000)
+    assert cost == pytest.approx(expected)

--- a/tests/test_gemini_api.py
+++ b/tests/test_gemini_api.py
@@ -27,7 +27,7 @@ def test_calc_cost_clamps_cached_tokens_to_avoid_negative_input_cost():
 
     cost = gemini_api.calc_cost("gemini-2.5-pro", usage)
 
-    assert cost == pytest.approx(150 * 0.125 / 1_000_000)
+    assert cost == pytest.approx(100 * 0.125 / 1_000_000)
 
 
 def test_calc_cost_handles_models_without_cache_pricing():

--- a/tests/test_provider_response_parsing.py
+++ b/tests/test_provider_response_parsing.py
@@ -41,6 +41,54 @@ def test_openai_extract_reasoning_ignores_missing_summary():
     assert openai_api.extract_reasoning(response) == ""
 
 
+def test_openai_calc_price_uses_reported_cached_tokens():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=1000,
+            output_tokens=200,
+            input_tokens_details=SimpleNamespace(cached_tokens=400),
+        )
+    )
+
+    cost = openai_api.calc_price("gpt-4o-mini", response)
+
+    expected = (600 * 0.15 / 1_000_000) + (400 * 0.075 / 1_000_000) + (200 * 0.60 / 1_000_000)
+    assert cost == pytest.approx(expected)
+
+
+def test_openai_calc_price_clamps_malformed_cached_tokens():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=0,
+            input_tokens_details=SimpleNamespace(cached_tokens=150),
+        )
+    )
+
+    cost = openai_api.calc_price("gpt-4o-mini", response)
+
+    assert cost == pytest.approx(100 * 0.075 / 1_000_000)
+
+
+def test_claude_calc_price_uses_reported_cache_creation_and_reads():
+    output = {
+        "input_tokens": 1000,
+        "output_tokens": 200,
+        "cache_creation": 300,
+        "cache_read": 400,
+    }
+
+    cost = claude_api.calc_price("claude-sonnet-4-5", output)
+
+    expected = (
+        (1000 * 3.00 / 1_000_000)
+        + (200 * 15.00 / 1_000_000)
+        + (300 * 3.75 / 1_000_000)
+        + (400 * 0.30 / 1_000_000)
+    )
+    assert cost == pytest.approx(expected)
+
+
 def test_gemini_process_output_rejects_empty_candidates():
     response = SimpleNamespace(candidates=[])
 

--- a/tests/test_provider_response_parsing.py
+++ b/tests/test_provider_response_parsing.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from src import gemini_api, objects, ollama_api, openai_api
+from src import claude_api, gemini_api, objects, ollama_api, openai_api
 
 
 def _loop_payload():
@@ -19,6 +19,20 @@ def _loop_payload():
         ],
     }
     return {"Bar_1": bar, "Bar_2": {**bar, "num": 2}, "Bar_3": {**bar, "num": 3}, "Bar_4": {**bar, "num": 4}}
+
+
+def _anthropic_completion(payload):
+    usage = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=50,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+    return [
+        SimpleNamespace(type="message_start", message=SimpleNamespace(usage=usage)),
+        SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(partial_json=payload)),
+        SimpleNamespace(type="message_stop"),
+    ]
 
 
 def test_openai_extract_reasoning_ignores_missing_summary():
@@ -39,6 +53,49 @@ def test_gemini_process_output_rejects_missing_parts():
 
     with pytest.raises(ValueError, match="Google response did not include generated content parts"):
         gemini_api.process_output(response)
+
+
+def test_claude_loop_gen_omits_cache_control_for_short_system_prompt(monkeypatch):
+    captured = {}
+    payload = json.dumps(_loop_payload())
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _anthropic_completion(payload)
+
+    fake_client = SimpleNamespace(messages=SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(claude_api, "initialize_anthropic_client", lambda: fake_client)
+    monkeypatch.setattr(claude_api.utils, "get_loop_prompt", lambda: "short system prompt")
+    monkeypatch.setattr(claude_api.utils, "save_messages_to_json", lambda *args, **kwargs: None)
+
+    midi_loop, messages, cost = claude_api.loop_gen(
+        "write a loop",
+        "claude-sonnet-4-5",
+    )
+
+    assert isinstance(midi_loop, objects.Loop)
+    assert "cache_control" not in captured["system"][0]
+    assert messages[0] == {"role": "system", "content": "short system prompt"}
+    assert cost > 0
+
+
+def test_claude_loop_gen_adds_cache_control_for_large_system_prompt(monkeypatch):
+    captured = {}
+    payload = json.dumps(_loop_payload())
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _anthropic_completion(payload)
+
+    fake_client = SimpleNamespace(messages=SimpleNamespace(create=fake_create))
+    long_prompt = "x" * claude_api.ANTHROPIC_CACHE_CONTROL_MIN_CHARS
+    monkeypatch.setattr(claude_api, "initialize_anthropic_client", lambda: fake_client)
+    monkeypatch.setattr(claude_api.utils, "get_loop_prompt", lambda: long_prompt)
+    monkeypatch.setattr(claude_api.utils, "save_messages_to_json", lambda *args, **kwargs: None)
+
+    claude_api.loop_gen("write a loop", "claude-sonnet-4-5")
+
+    assert captured["system"][0]["cache_control"] == {"type": "ephemeral"}
 
 
 def test_ollama_loop_gen_accepts_missing_thinking(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,15 @@ def test_beats_to_duration_name_formats_standard_and_nonstandard_lengths(beats, 
     assert utils.beats_to_duration_name(beats) == expected
 
 
+def test_split_reported_cache_tokens_uses_reported_counts():
+    assert utils.split_reported_cache_tokens(1000, 400) == (600, 400)
+
+
+def test_split_reported_cache_tokens_clamps_malformed_counts():
+    assert utils.split_reported_cache_tokens(100, 150) == (0, 100)
+    assert utils.split_reported_cache_tokens(100, -20) == (100, 0)
+
+
 def test_scale_returns_expected_note_family_for_c_major():
     scale_notes = utils.scale("C", "major")
 


### PR DESCRIPTION
﻿## Summary

Fixes #16 by removing the speculative Gemini implicit-cache storage charge and making provider cost accounting rely on cache usage fields reported by each API.

This is an alternate approach to #35. Rather than scaling a hard-coded implicit-cache TTL assumption, this removes the undocumented storage estimate from per-call Gemini pricing, caps malformed cached-token math, and keeps cache savings tied to actual provider usage data.

Closes #36 because this changes the direction away from adding explicit Gemini context-cache management for LoopGPT's current prompt shape. Normal LoopGPT prompts are short enough that prompt caching should remain opportunistic instead of a first-class optimization path.

## Changes

- Removes Gemini's hard-coded implicit cache storage TTL estimate from `calc_cost`.
- Keeps Gemini cached-input pricing only when `cached_content_token_count` is reported.
- Adds shared cache-token splitting logic that caps cached tokens to reported total tokens so input cost cannot go negative.
- Applies that shared guard to OpenAI cached-token accounting as well.
- Gates Anthropic `cache_control` so the normal short system prompt is not marked as cacheable unless the stable prompt crosses a size threshold.
- Preserves Anthropic usage-based pricing for reported cache creation and cache reads.
- Documents that normal LoopGPT prompt-cache savings are limited and should not be forced with prompt padding.
- Adds focused regression coverage for Gemini, OpenAI, Anthropic, and the shared cache-token helper.

## Relationship to prior work

- Stems from #16, which identified Gemini cache storage cost overcounting.
- References #35 as the previous fix path; this PR takes the simpler usage-reported cost-accounting approach instead of estimating storage from an assumed TTL.
- Closes #36 by making explicit Gemini cache support unnecessary for this branch's scope and documenting the expectation that normal LoopGPT requests are usually below provider cache thresholds.

## Testing

- `python -m pytest` - 101 passed, 2 dependency deprecation warnings
