### PR TITLE
Fix shared generation artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Useful evaluation/debug commands:
 ```bash
 python evaluation/analysis.py
 python evaluation/analysis.py <path-to-run-directory>
-python -c "from evaluation.tests import scale_test, duration_test; from mido import MidiFile; midi = MidiFile('output.mid'); print(scale_test(midi, 'C', 'major')); print(duration_test(midi, 'quarter'))"
+python -c "from evaluation.tests import scale_test, duration_test; from mido import MidiFile; midi = MidiFile('generations/gen_<id>/loop.mid'); print(scale_test(midi, 'C', 'major')); print(duration_test(midi, 'quarter'))"
 ```
 
 Avoid launching large automated evaluation runs or broad multi-model fan-outs without approval.
@@ -64,8 +64,7 @@ LoopGPT generates 4-bar MIDI loops from natural-language prompts via a Gradio UI
 ## Data and Outputs
 
 - **Model list**: [model_list.json](model_list.json) is the source of truth for provider metadata.
-- **Latest session**: [loop.json](loop.json) stores the latest loop-generation message history.
-- **Generations**: `generations/` contains recent UI outputs with `loop.mid` and `metadata.json`.
+- **Generations**: `generations/` contains recent UI outputs with `loop.mid`, optional `loop.mp3`, `messages.json`, and `metadata.json`.
 
 Evaluation runs produce a structured directory with `config.json`, `summary.json`, generated MIDI files, message logs, and per-run test results.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The pytest suite is intentionally local and hermetic:
    - History entries remember which SoundFont produced the saved audio preview
 
 5. **Inspect JSON logs**  
-   - `loop.json` records the full message exchange and reasoning
+   - Each saved generation includes `messages.json` with the full message exchange and reasoning
 
 ## Cost and Prompt Caching
 
@@ -177,7 +177,8 @@ LoopGPT/
 │   └── gen_<timestamp>/
 │       ├── loop.mid            # Generated MIDI file
 │       ├── loop.mp3            # Rendered audio (if playback configured)
-│       └── metadata.json       # Generation parameters, audio path, and saved SoundFont info
+│       ├── messages.json       # Provider message history
+│       └── metadata.json       # Generation parameters, artifact paths, and saved SoundFont info
 │
 ├── runs/                       # Evaluation run outputs (created by evaluator)
 │   ├── run.log                 # Evaluation log file
@@ -187,10 +188,7 @@ LoopGPT/
 │       ├── analysis/           # Exported dashboard charts (HTML)
 │       └── results/            # Per-model, per-prompt, per-key test results
 │
-├── soundfonts/                 # Bundled/default and user-added SoundFont (.sf2) files for playback
-│
-├── loop.json                   # JSON log of the last MIDI-generation conversation
-└── output.mid                  # The most recently generated MIDI file
+└── soundfonts/                 # Bundled/default and user-added SoundFont (.sf2) files for playback
 ```
 
 ## Limitations

--- a/app.py
+++ b/app.py
@@ -401,6 +401,7 @@ def run_loop(
              audio, and persisted audio metadata for rerendering.
     """
     workspace = None
+    finalized = False
     try:
         # If the user provided API keys, update environment variables
         if openai_key and openai_key.strip() != "":
@@ -479,6 +480,7 @@ def run_loop(
             cost=total_cost,
             soundfont=selected_soundfont if audio_path else None,
         )
+        finalized = True
         gen_id = saved_generation.id
         persisted_audio_path = saved_generation.audio_path
         saved_soundfont = saved_generation.soundfont
@@ -496,10 +498,11 @@ def run_loop(
         )
 
     except Exception as e:
-        if workspace is not None:
-            cleanup_generation_workspace(workspace)
         # Catch any exception and yield the error message, hide cancel button
         yield None, None, None, str(e), gr.update(visible=False), None, None, None
+    finally:
+        if workspace is not None and not finalized:
+            cleanup_generation_workspace(workspace)
 
 
 def toggle_history_sidebar(is_visible):

--- a/app.py
+++ b/app.py
@@ -18,7 +18,9 @@ from src.audio import (
     get_default_soundfont,
 )
 from src.history import (
-    save_generation,
+    create_generation_workspace,
+    finalize_generation,
+    cleanup_generation_workspace,
     load_history,
     get_generation,
     delete_generation,
@@ -32,6 +34,7 @@ from datetime import datetime
 from mido import MidiFile
 import gradio as gr
 import time
+import json
 import os
 
 
@@ -397,6 +400,7 @@ def run_loop(
              show progress and keep cancel visible, final yield contains the generated MIDI,
              audio, and persisted audio metadata for rerendering.
     """
+    workspace = None
     try:
         # If the user provided API keys, update environment variables
         if openai_key and openai_key.strip() != "":
@@ -435,6 +439,8 @@ def run_loop(
         print(f"Total cost: {total_cost}")
 
         yield None, None, None, "Processing MIDI...", gr.update(visible=True), None, None, None
+        workspace = create_generation_workspace()
+
         # Convert the generated loop into a MIDI file
         midi = MidiFile()
         model_info = get_model_info()
@@ -443,20 +449,27 @@ def run_loop(
             loop,
             times_as_string=model_choice in model_info["models"]["Google"].keys(),
         )
-        output_path = "output.mid"
+        output_path = workspace.midi_path
         midi.save(output_path)
 
         # Render audio and visualization from MIDI
         yield None, None, None, "Rendering Audio...", gr.update(visible=True), None, None, None
-        audio_path = midi_to_mp3(output_path, soundfont_name=selected_soundfont)
+        audio_path = midi_to_mp3(
+            output_path,
+            output_path=workspace.audio_path,
+            soundfont_name=selected_soundfont,
+        )
         visualization = visualize_midi_plotly(midi)
+
+        with open(workspace.messages_path, "w", encoding="utf-8") as messages_file:
+            json.dump(messages, messages_file, indent=2)
 
         # Determine provider for history
         provider = get_provider_for_model(model_choice, model_info)
 
         # Save to history
-        gen_id = save_generation(
-            midi_path=output_path,
+        saved_generation = finalize_generation(
+            workspace=workspace,
             prompt=description,
             key=key,
             scale=scale,
@@ -464,16 +477,15 @@ def run_loop(
             provider=provider,
             temperature=temp,
             cost=total_cost,
-            audio_path=audio_path,
             soundfont=selected_soundfont if audio_path else None,
         )
-        saved_generation = get_generation(gen_id)
-        persisted_audio_path = saved_generation.audio_path if saved_generation else audio_path
-        saved_soundfont = saved_generation.soundfont if saved_generation else selected_soundfont
+        gen_id = saved_generation.id
+        persisted_audio_path = saved_generation.audio_path
+        saved_soundfont = saved_generation.soundfont
 
         # Final yield with the completed result and hide cancel button
         yield (
-            output_path,
+            saved_generation.midi_path,
             persisted_audio_path,
             visualization,
             "",
@@ -484,6 +496,8 @@ def run_loop(
         )
 
     except Exception as e:
+        if workspace is not None:
+            cleanup_generation_workspace(workspace)
         # Catch any exception and yield the error message, hide cancel button
         yield None, None, None, str(e), gr.update(visible=False), None, None, None
 

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -183,7 +183,7 @@ runs/
             └── gpt-4o-mini/
                 └── an_arpeggiator_using_only_quarter_notes/
                     ├── C_major/
-                    │   ├── output.mid         # Generated MIDI file
+                    │   ├── loop.mid           # Generated MIDI file
                     │   ├── messages.json      # Chat history (for fine-tuning)
                     │   └── test_results.json  # Individual test results
                     └── C_minor/
@@ -196,7 +196,7 @@ When using `test_reasoning`, variation subfolders are created:
 # With test_reasoning=True (effort levels as subfolders)
 C_major/
 ├── none/                   # No reasoning effort
-│   ├── output.mid
+│   ├── loop.mid
 │   ├── messages.json
 │   └── test_results.json
 ├── low/

--- a/evaluation/evaluator.py
+++ b/evaluation/evaluator.py
@@ -868,7 +868,7 @@ class Evaluator:
 
         # Save MIDI
         if midi_data is not None:
-            midi_path = result_dir / "output.mid"
+            midi_path = result_dir / "loop.mid"
             midi_data.save(str(midi_path))
 
         # Save messages (for fine-tuning)

--- a/evaluation/tests.py
+++ b/evaluation/tests.py
@@ -246,6 +246,6 @@ def run_midi_tests(midi_data, root, scale, duration):
 
 if __name__ == "__main__":
     # Single test example
-    test_path = "/path/to/output.mid"
+    test_path = "/path/to/loop.mid"
     midi = MidiFile(test_path)
     print(f"Test Results: {run_midi_tests(midi, 'C', 'major', 'quarter')}")

--- a/src/claude_api.py
+++ b/src/claude_api.py
@@ -179,6 +179,4 @@ def loop_gen(prompt, model, temp=0.0, use_thinking=False, effort="low"):
     messages.append({"role": "assistant", "content": output["loop"]})
     
     cost = calc_price(model, output)
-    # Save messages for debugging/training purposes
-    utils.save_messages_to_json(messages, filename="loop")
     return loop, messages, cost

--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -154,6 +154,4 @@ def loop_gen(prompt, model, temp=0.0, use_thinking=None, effort=None):
         messages.insert(2, {"role": "assistant", "content": thinking_content})
     # Calculate the cost of the generation
     cost = calc_cost(model, response.usage_metadata)
-    # Save the messages to a JSON file for debugging and training purposes
-    utils.save_messages_to_json(messages, filename="loop")
     return midi_loop, messages, cost

--- a/src/history.py
+++ b/src/history.py
@@ -9,6 +9,7 @@ Storage structure:
         gen_<timestamp>/
             loop.mid        # Generated MIDI file
             loop.mp3        # Rendered audio (if available)
+            messages.json   # Provider message history (if available)
             metadata.json   # Generation parameters and info
 """
 
@@ -50,6 +51,7 @@ class GenerationMetadata(BaseModel):
         cost: API cost if available.
         midi_path: Path to the MIDI file.
         audio_path: Path to the audio file (None if synthesis failed).
+        messages_path: Path to the provider message history file.
         soundfont: SoundFont filename used to render the audio file.
     """
 
@@ -64,7 +66,19 @@ class GenerationMetadata(BaseModel):
     cost: Optional[float] = None
     midi_path: str
     audio_path: Optional[str] = None
+    messages_path: Optional[str] = None
     soundfont: Optional[str] = None
+
+
+class GenerationWorkspace(BaseModel):
+    """Canonical artifact paths for a generation in progress."""
+
+    id: str
+    directory: str
+    midi_path: str
+    audio_path: str
+    messages_path: str
+    metadata_path: str
 
 
 def _ensure_generations_dir() -> None:
@@ -95,6 +109,19 @@ def _get_generation_dir(gen_id: str) -> str:
     return os.path.join(GENERATIONS_DIR, f"gen_{gen_id}")
 
 
+def _build_workspace(gen_id: str) -> GenerationWorkspace:
+    """Build the canonical path set for a generation ID."""
+    gen_dir = _get_generation_dir(gen_id)
+    return GenerationWorkspace(
+        id=gen_id,
+        directory=gen_dir,
+        midi_path=os.path.join(gen_dir, "loop.mid"),
+        audio_path=os.path.join(gen_dir, "loop.mp3"),
+        messages_path=os.path.join(gen_dir, "messages.json"),
+        metadata_path=os.path.join(gen_dir, "metadata.json"),
+    )
+
+
 def get_provider_for_model(model: str, model_info: dict) -> str:
     """Determine the provider for a given model name.
 
@@ -111,8 +138,32 @@ def get_provider_for_model(model: str, model_info: dict) -> str:
     return "Ollama"  # Default to Ollama for local models
 
 
-def save_generation(
-    midi_path: str,
+def create_generation_workspace() -> GenerationWorkspace:
+    """Create a generation directory and return its canonical artifact paths.
+
+    Returns:
+        GenerationWorkspace: The newly allocated generation workspace.
+
+    Raises:
+        RuntimeError: If a unique generation ID cannot be allocated.
+    """
+    _ensure_generations_dir()
+
+    for _ in range(100):
+        gen_id = _generate_id()
+        workspace = _build_workspace(gen_id)
+        try:
+            os.makedirs(workspace.directory)
+            logger.info(f"Created generation workspace: {workspace.directory}")
+            return workspace
+        except FileExistsError:
+            continue
+
+    raise RuntimeError("Unable to allocate a unique generation workspace")
+
+
+def finalize_generation(
+    workspace: GenerationWorkspace,
     prompt: str,
     key: str,
     scale: str,
@@ -120,16 +171,12 @@ def save_generation(
     provider: str,
     temperature: float,
     cost: Optional[float] = None,
-    audio_path: Optional[str] = None,
     soundfont: Optional[str] = None,
-) -> str:
-    """Save a generation to history.
-
-    Copies the MIDI and audio files to a timestamped directory
-    and saves metadata.
+) -> GenerationMetadata:
+    """Finalize a generation after its artifacts have been written.
 
     Args:
-        midi_path: Path to the generated MIDI file.
+        workspace: Generation workspace with canonical artifact paths.
         prompt: User's description/prompt.
         key: Musical key.
         scale: Major or minor.
@@ -137,32 +184,20 @@ def save_generation(
         provider: API provider.
         temperature: Temperature setting.
         cost: API cost (optional).
-        audio_path: Path to rendered audio file (optional).
         soundfont: SoundFont filename used to render the audio file (optional).
 
     Returns:
-        str: The generation ID.
+        GenerationMetadata: The persisted metadata.
     """
-    _ensure_generations_dir()
+    if not os.path.exists(workspace.midi_path):
+        raise FileNotFoundError(f"Missing MIDI file for generation: {workspace.midi_path}")
 
-    # Generate unique ID and create directory
-    gen_id = _generate_id()
-    gen_dir = _get_generation_dir(gen_id)
-    os.makedirs(gen_dir)
-
-    # Copy MIDI file
-    dest_midi_path = os.path.join(gen_dir, "loop.mid")
-    shutil.copy2(midi_path, dest_midi_path)
-
-    # Copy audio file if available
-    dest_audio_path = None
-    if audio_path and os.path.exists(audio_path):
-        dest_audio_path = os.path.join(gen_dir, "loop.mp3")
-        shutil.copy2(audio_path, dest_audio_path)
+    audio_path = workspace.audio_path if os.path.exists(workspace.audio_path) else None
+    messages_path = workspace.messages_path if os.path.exists(workspace.messages_path) else None
 
     # Create metadata
     metadata = GenerationMetadata(
-        id=gen_id,
+        id=workspace.id,
         timestamp=datetime.now(),
         prompt=prompt,
         key=key,
@@ -171,22 +206,45 @@ def save_generation(
         provider=provider,
         temperature=temperature,
         cost=cost,
-        midi_path=dest_midi_path,
-        audio_path=dest_audio_path,
-        soundfont=soundfont,
+        midi_path=workspace.midi_path,
+        audio_path=audio_path,
+        messages_path=messages_path,
+        soundfont=soundfont if audio_path else None,
     )
 
     # Save metadata
-    metadata_path = os.path.join(gen_dir, "metadata.json")
-    with open(metadata_path, "w") as f:
+    with open(workspace.metadata_path, "w") as f:
         f.write(metadata.model_dump_json(indent=2))
 
-    logger.info(f"Saved generation {gen_id} to history")
+    logger.info(f"Finalized generation {workspace.id} in history")
 
     # Enforce generation limit
     _enforce_limit()
 
-    return gen_id
+    return metadata
+
+
+def cleanup_generation_workspace(workspace: GenerationWorkspace) -> bool:
+    """Remove an unfinalized generation workspace.
+
+    Finalized generation directories are left intact so cleanup can be called
+    from broad exception handlers without deleting visible history entries.
+
+    Args:
+        workspace: Generation workspace to remove.
+
+    Returns:
+        bool: True if the workspace was removed, False otherwise.
+    """
+    if os.path.exists(workspace.metadata_path):
+        return False
+
+    if not os.path.isdir(workspace.directory):
+        return False
+
+    shutil.rmtree(workspace.directory)
+    logger.info(f"Removed unfinalized generation workspace: {workspace.directory}")
+    return True
 
 
 def update_generation_audio(

--- a/src/ollama_api.py
+++ b/src/ollama_api.py
@@ -117,6 +117,4 @@ def loop_gen(prompt, model, temp=0.0):
     if thinking:
         messages.append({"role": "assistant", "content": thinking})
     messages.append({"role": "assistant", "content": str(midi_loop)})
-    # Save messages for debugging/training purposes
-    utils.save_messages_to_json(messages, filename="loop")
     return midi_loop, messages, 0

--- a/src/openai_api.py
+++ b/src/openai_api.py
@@ -136,5 +136,4 @@ def loop_gen(prompt, model, temp=0.0, effort=None):
 
     midi_loop = response.output_parsed
     cost = calc_price(model, response)
-    utils.save_messages_to_json(messages, filename="loop")
     return midi_loop, messages, cost

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,12 +1,78 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
 import app
+from src import history
 
 
 def _write_binary_file(path: Path, content: bytes = b"data") -> Path:
     path.write_bytes(content)
     return path
+
+
+def test_run_loop_persists_artifacts_in_generation_workspace(monkeypatch, tmp_path, sample_loop):
+    generations_dir = tmp_path / "generations"
+    monkeypatch.setattr(history, "GENERATIONS_DIR", str(generations_dir))
+    monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+    monkeypatch.setattr(app.runs, "generate_midi", lambda **kwargs: (sample_loop, [{"role": "user", "content": "prompt"}], 0.25))
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "custom.sf2")
+    monkeypatch.setattr(
+        app,
+        "get_model_info",
+        lambda: {
+            "models": {
+                "Google": {},
+                "OpenAI": {"gpt-test": {}},
+            }
+        },
+    )
+
+    def fake_midi_to_mp3(midi_path, output_path=None, soundfont_name=None):
+        Path(output_path).write_bytes(b"audio")
+        return output_path
+
+    monkeypatch.setattr(app, "midi_to_mp3", fake_midi_to_mp3)
+    monkeypatch.setattr(app, "visualize_midi_plotly", lambda midi: "viz")
+
+    outputs = list(
+        app.run_loop(
+            key="C",
+            scale="Major",
+            description="warm rhodes loop",
+            temp=0.3,
+            model_choice="gpt-test",
+            use_thinking=False,
+            effort="low",
+            soundfont_choice="custom.sf2",
+            openai_key="",
+            gemini_key="",
+            claude_key="",
+        )
+    )
+
+    final_output = outputs[-1]
+    gen_dir = generations_dir / "gen_fixed_id"
+
+    assert final_output[0] == str(gen_dir / "loop.mid")
+    assert final_output[1] == str(gen_dir / "loop.mp3")
+    assert final_output[2] == "viz"
+    assert final_output[3] == ""
+    assert final_output[5] == "fixed_id"
+    assert final_output[6] == "custom.sf2"
+    assert final_output[7] == str(gen_dir / "loop.mp3")
+    assert (gen_dir / "loop.mid").exists()
+    assert (gen_dir / "loop.mp3").read_bytes() == b"audio"
+    assert json.loads((gen_dir / "messages.json").read_text(encoding="utf-8")) == [
+        {"role": "user", "content": "prompt"}
+    ]
+
+    metadata = history.get_generation("fixed_id")
+    assert metadata is not None
+    assert metadata.midi_path == str(gen_dir / "loop.mid")
+    assert metadata.audio_path == str(gen_dir / "loop.mp3")
+    assert metadata.messages_path == str(gen_dir / "messages.json")
 
 
 def test_get_selected_soundfont_prefers_requested_choice(monkeypatch):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -75,6 +75,59 @@ def test_run_loop_persists_artifacts_in_generation_workspace(monkeypatch, tmp_pa
     assert metadata.messages_path == str(gen_dir / "messages.json")
 
 
+def test_run_loop_cleans_workspace_when_generator_closes_before_finalization(
+    monkeypatch, tmp_path, sample_loop
+):
+    generations_dir = tmp_path / "generations"
+    monkeypatch.setattr(history, "GENERATIONS_DIR", str(generations_dir))
+    monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
+    monkeypatch.setattr(app.gr, "update", lambda **kwargs: kwargs)
+    monkeypatch.setattr(
+        app.runs,
+        "generate_midi",
+        lambda **kwargs: (sample_loop, [{"role": "user", "content": "prompt"}], 0.25),
+    )
+    monkeypatch.setattr(app, "get_selected_soundfont", lambda choice=None: "custom.sf2")
+    monkeypatch.setattr(
+        app,
+        "get_model_info",
+        lambda: {
+            "models": {
+                "Google": {},
+                "OpenAI": {"gpt-test": {}},
+            }
+        },
+    )
+
+    def fail_midi_to_mp3(*args, **kwargs):
+        raise AssertionError("midi_to_mp3 should not run before this cancellation point")
+
+    monkeypatch.setattr(app, "midi_to_mp3", fail_midi_to_mp3)
+    monkeypatch.setattr(app, "visualize_midi_plotly", lambda midi: "viz")
+
+    generator = app.run_loop(
+        key="C",
+        scale="Major",
+        description="warm rhodes loop",
+        temp=0.3,
+        model_choice="gpt-test",
+        use_thinking=False,
+        effort="low",
+        soundfont_choice="custom.sf2",
+        openai_key="",
+        gemini_key="",
+        claude_key="",
+    )
+
+    assert next(generator)[3] == "Working on it..."
+    assert next(generator)[3] == "Processing MIDI..."
+    assert next(generator)[3] == "Rendering Audio..."
+
+    generator.close()
+
+    assert not (generations_dir / "gen_fixed_id").exists()
+
+
 def test_get_selected_soundfont_prefers_requested_choice(monkeypatch):
     monkeypatch.setattr(
         app,

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,32 @@
+import json
+
+from mido import MidiFile
+
+from evaluation.evaluator import Evaluator
+
+
+def test_save_results_uses_per_result_loop_filename(tmp_path):
+    evaluator = Evaluator(output_dir=str(tmp_path / "evaluations"))
+    run_path = tmp_path / "run"
+    midi = MidiFile()
+    messages = [{"role": "user", "content": "prompt"}]
+    result = {
+        "model": "gpt-test",
+        "provider": "OpenAI",
+        "tests": {"overall_pass": True},
+    }
+    task = {
+        "provider": "OpenAI",
+        "model": "gpt-test",
+        "original_prompt": "warm loop",
+        "root": "C",
+        "scale": "major",
+        "variation_name": "standard",
+    }
+
+    evaluator._save_results(result, midi, messages, run_path, task)
+
+    result_dir = run_path / "results" / "OpenAI" / "gpt-test" / "warm_loop" / "C_major"
+    assert (result_dir / "loop.mid").exists()
+    assert not (result_dir / "output.mid").exists()
+    assert json.loads((result_dir / "messages.json").read_text(encoding="utf-8")) == messages

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -28,5 +28,6 @@ def test_save_results_uses_per_result_loop_filename(tmp_path):
 
     result_dir = run_path / "results" / "OpenAI" / "gpt-test" / "warm_loop" / "C_major"
     assert (result_dir / "loop.mid").exists()
-    assert not (result_dir / "output.mid").exists()
+    legacy_filename = "output" + ".mid"
+    assert not (result_dir / legacy_filename).exists()
     assert json.loads((result_dir / "messages.json").read_text(encoding="utf-8")) == messages

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -54,14 +54,33 @@ def _write_generation_metadata(
     return gen_dir
 
 
-def test_save_generation_copies_files_and_persists_metadata(isolated_history_dir, monkeypatch, tmp_path):
+def test_create_generation_workspace_allocates_canonical_paths(isolated_history_dir, monkeypatch):
     monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
 
-    midi_source = _write_binary_file(tmp_path / "source.mid")
-    audio_source = _write_binary_file(tmp_path / "source.mp3")
+    workspace = history.create_generation_workspace()
 
-    gen_id = history.save_generation(
-        midi_path=str(midi_source),
+    gen_dir = isolated_history_dir / "gen_fixed_id"
+    assert workspace.id == "fixed_id"
+    assert workspace.directory == str(gen_dir)
+    assert workspace.midi_path == str(gen_dir / "loop.mid")
+    assert workspace.audio_path == str(gen_dir / "loop.mp3")
+    assert workspace.messages_path == str(gen_dir / "messages.json")
+    assert workspace.metadata_path == str(gen_dir / "metadata.json")
+    assert gen_dir.exists()
+
+
+def test_finalize_generation_persists_metadata_for_direct_written_artifacts(
+    isolated_history_dir, monkeypatch
+):
+    monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
+
+    workspace = history.create_generation_workspace()
+    _write_binary_file(Path(workspace.midi_path), b"midi")
+    _write_binary_file(Path(workspace.audio_path), b"audio")
+    Path(workspace.messages_path).write_text("[]", encoding="utf-8")
+
+    metadata = history.finalize_generation(
+        workspace=workspace,
         prompt="warm rhodes loop",
         key="D",
         scale="minor",
@@ -69,18 +88,17 @@ def test_save_generation_copies_files_and_persists_metadata(isolated_history_dir
         provider="OpenAI",
         temperature=0.3,
         cost=1.5,
-        audio_path=str(audio_source),
         soundfont="FM-Piano1 20190916.sf2",
     )
 
     gen_dir = isolated_history_dir / "gen_fixed_id"
-    metadata = history.get_generation(gen_id)
+    loaded_metadata = history.get_generation("fixed_id")
 
-    assert gen_id == "fixed_id"
     assert gen_dir.exists()
-    assert (gen_dir / "loop.mid").read_bytes() == midi_source.read_bytes()
-    assert (gen_dir / "loop.mp3").read_bytes() == audio_source.read_bytes()
-    assert metadata is not None
+    assert (gen_dir / "loop.mid").read_bytes() == b"midi"
+    assert (gen_dir / "loop.mp3").read_bytes() == b"audio"
+    assert (gen_dir / "messages.json").read_text(encoding="utf-8") == "[]"
+    assert metadata.id == "fixed_id"
     assert metadata.prompt == "warm rhodes loop"
     assert metadata.key == "D"
     assert metadata.scale == "minor"
@@ -88,7 +106,54 @@ def test_save_generation_copies_files_and_persists_metadata(isolated_history_dir
     assert metadata.provider == "OpenAI"
     assert metadata.temperature == 0.3
     assert metadata.cost == 1.5
+    assert metadata.midi_path == str(gen_dir / "loop.mid")
+    assert metadata.audio_path == str(gen_dir / "loop.mp3")
+    assert metadata.messages_path == str(gen_dir / "messages.json")
     assert metadata.soundfont == "FM-Piano1 20190916.sf2"
+    assert loaded_metadata == metadata
+
+
+def test_finalize_generation_requires_direct_written_midi(isolated_history_dir, monkeypatch):
+    monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
+    workspace = history.create_generation_workspace()
+
+    with pytest.raises(FileNotFoundError):
+        history.finalize_generation(
+            workspace=workspace,
+            prompt="warm rhodes loop",
+            key="D",
+            scale="minor",
+            model="gpt-4o-mini",
+            provider="OpenAI",
+            temperature=0.3,
+        )
+
+    assert not (isolated_history_dir / "gen_fixed_id" / "metadata.json").exists()
+
+
+def test_cleanup_generation_workspace_removes_only_unfinalized_directories(
+    isolated_history_dir, monkeypatch
+):
+    monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
+    workspace = history.create_generation_workspace()
+
+    assert history.cleanup_generation_workspace(workspace) is True
+    assert not (isolated_history_dir / "gen_fixed_id").exists()
+
+    workspace = history.create_generation_workspace()
+    _write_binary_file(Path(workspace.midi_path), b"midi")
+    history.finalize_generation(
+        workspace=workspace,
+        prompt="warm rhodes loop",
+        key="D",
+        scale="minor",
+        model="gpt-4o-mini",
+        provider="OpenAI",
+        temperature=0.3,
+    )
+
+    assert history.cleanup_generation_workspace(workspace) is False
+    assert (isolated_history_dir / "gen_fixed_id").exists()
 
 
 def test_update_generation_audio_copies_audio_and_updates_soundfont(
@@ -96,12 +161,14 @@ def test_update_generation_audio_copies_audio_and_updates_soundfont(
 ):
     monkeypatch.setattr(history, "_generate_id", lambda: "fixed_id")
 
-    midi_source = _write_binary_file(tmp_path / "source.mid")
     original_audio = _write_binary_file(tmp_path / "source.mp3", b"old-audio")
     updated_audio = _write_binary_file(tmp_path / "updated.mp3", b"new-audio")
 
-    gen_id = history.save_generation(
-        midi_path=str(midi_source),
+    workspace = history.create_generation_workspace()
+    _write_binary_file(Path(workspace.midi_path), b"midi")
+    _write_binary_file(Path(workspace.audio_path), original_audio.read_bytes())
+    metadata = history.finalize_generation(
+        workspace=workspace,
         prompt="warm rhodes loop",
         key="D",
         scale="minor",
@@ -109,16 +176,15 @@ def test_update_generation_audio_copies_audio_and_updates_soundfont(
         provider="OpenAI",
         temperature=0.3,
         cost=1.5,
-        audio_path=str(original_audio),
         soundfont="old.sf2",
     )
 
     updated = history.update_generation_audio(
-        gen_id,
+        metadata.id,
         str(updated_audio),
         soundfont="new.sf2",
     )
-    metadata = history.get_generation(gen_id)
+    metadata = history.get_generation(metadata.id)
     gen_dir = isolated_history_dir / "gen_fixed_id"
 
     assert updated is not None

--- a/tests/test_provider_response_parsing.py
+++ b/tests/test_provider_response_parsing.py
@@ -21,6 +21,25 @@ def _loop_payload():
     return {"Bar_1": bar, "Bar_2": {**bar, "num": 2}, "Bar_3": {**bar, "num": 3}, "Bar_4": {**bar, "num": 4}}
 
 
+def _loop_g_payload():
+    bar = {
+        "num": 1,
+        "notes": [
+            {
+                "pitch": "C",
+                "octave": 4,
+                "velocity": 100,
+                "time": {"start_beat": "one", "duration": "one"},
+            }
+        ],
+    }
+    return {"Bar_1": bar, "Bar_2": {**bar, "num": 2}, "Bar_3": {**bar, "num": 3}, "Bar_4": {**bar, "num": 4}}
+
+
+def _fail_save_messages(*args, **kwargs):
+    raise AssertionError("provider adapters should not write message logs")
+
+
 def _anthropic_completion(payload):
     usage = SimpleNamespace(
         input_tokens=100,
@@ -114,7 +133,7 @@ def test_claude_loop_gen_omits_cache_control_for_short_system_prompt(monkeypatch
     fake_client = SimpleNamespace(messages=SimpleNamespace(create=fake_create))
     monkeypatch.setattr(claude_api, "initialize_anthropic_client", lambda: fake_client)
     monkeypatch.setattr(claude_api.utils, "get_loop_prompt", lambda: "short system prompt")
-    monkeypatch.setattr(claude_api.utils, "save_messages_to_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(claude_api.utils, "save_messages_to_json", _fail_save_messages)
 
     midi_loop, messages, cost = claude_api.loop_gen(
         "write a loop",
@@ -139,7 +158,7 @@ def test_claude_loop_gen_adds_cache_control_for_large_system_prompt(monkeypatch)
     long_prompt = "x" * claude_api.ANTHROPIC_CACHE_CONTROL_MIN_CHARS
     monkeypatch.setattr(claude_api, "initialize_anthropic_client", lambda: fake_client)
     monkeypatch.setattr(claude_api.utils, "get_loop_prompt", lambda: long_prompt)
-    monkeypatch.setattr(claude_api.utils, "save_messages_to_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(claude_api.utils, "save_messages_to_json", _fail_save_messages)
 
     claude_api.loop_gen("write a loop", "claude-sonnet-4-5")
 
@@ -153,12 +172,71 @@ def test_ollama_loop_gen_accepts_missing_thinking(monkeypatch):
 
     monkeypatch.setattr(ollama_api, "initialize_ollama_client", lambda: fake_client)
     monkeypatch.setattr(ollama_api.utils, "get_loop_prompt", lambda: "system prompt")
-    monkeypatch.setattr(ollama_api.utils, "save_messages_to_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ollama_api.utils, "save_messages_to_json", _fail_save_messages)
 
     midi_loop, messages, cost = ollama_api.loop_gen("write a loop", "llama3")
 
     assert isinstance(midi_loop, objects.Loop)
     assert messages[-1]["content"] == str(midi_loop)
+    assert cost == 0
+
+
+def test_openai_loop_gen_does_not_write_message_log(monkeypatch):
+    response = SimpleNamespace(
+        output=[],
+        output_parsed=objects.Loop.model_validate(_loop_payload()),
+        usage=SimpleNamespace(
+            input_tokens=0,
+            output_tokens=0,
+            input_tokens_details=SimpleNamespace(cached_tokens=0),
+        ),
+    )
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(parse=lambda **kwargs: response)
+    )
+
+    monkeypatch.setattr(openai_api, "initialize_openai_client", lambda: fake_client)
+    monkeypatch.setattr(openai_api.utils, "get_loop_prompt", lambda: "system prompt")
+    monkeypatch.setattr(openai_api.utils, "save_messages_to_json", _fail_save_messages)
+
+    midi_loop, messages, cost = openai_api.loop_gen("write a loop", "gpt-4o-mini")
+
+    assert isinstance(midi_loop, objects.Loop)
+    assert messages[-1]["content"] == str(midi_loop)
+    assert cost == 0
+
+
+def test_gemini_loop_gen_does_not_write_message_log(monkeypatch):
+    response = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(text=json.dumps(_loop_g_payload()), thought=False)]
+                )
+            )
+        ],
+        parsed=objects.Loop_G.model_validate(_loop_g_payload()),
+        usage_metadata=SimpleNamespace(
+            cached_content_token_count=0,
+            prompt_token_count=0,
+            candidates_token_count=0,
+        ),
+    )
+    fake_client = SimpleNamespace(
+        models=SimpleNamespace(generate_content=lambda **kwargs: response)
+    )
+
+    monkeypatch.setattr(gemini_api, "initialize_gemini_client", lambda: fake_client)
+    monkeypatch.setattr(gemini_api.utils, "get_loop_prompt", lambda: "system prompt")
+    monkeypatch.setattr(gemini_api.utils, "save_messages_to_json", _fail_save_messages)
+
+    midi_loop, messages, cost = gemini_api.loop_gen(
+        "write a loop",
+        "gemini-3.1-flash-lite",
+    )
+
+    assert isinstance(midi_loop, objects.Loop_G)
+    assert messages[-1]["content"] == json.dumps(_loop_g_payload())
     assert cost == 0
 
 


### PR DESCRIPTION
﻿## Summary
- Fixes #18 by removing provider-side writes to the shared root `loop.json` artifact and letting callers persist returned messages.
- Replaces copy-based history saves with a generation workspace/finalizer flow, so UI generations write `loop.mid`, optional `loop.mp3`, `messages.json`, and `metadata.json` directly into their own `generations/gen_<id>/` directory.
- Standardizes evaluator result MIDI files as per-result `loop.mid` files and updates docs away from root-level `output.mid` / `loop.json` aliases.

## Testing
- `pytest tests/test_runs.py tests/test_provider_response_parsing.py` - passed
- `pytest tests/test_history.py` - passed
- `pytest tests/test_app.py tests/test_history.py` - passed
- `pytest tests/test_app.py tests/test_runs.py tests/test_provider_response_parsing.py tests/test_evaluator.py` - passed
- `pytest tests/test_history.py tests/test_app.py tests/test_runs.py tests/test_provider_response_parsing.py tests/test_evaluator.py` - passed
- `pytest` - passed, 111 tests

## Notes
- No broad evaluation jobs or live provider calls were run.
