### PR TITLE
[codex] fix double-flat enharmonic MIDI conversion

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -14,35 +14,77 @@ NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
 
 # Enharmonic note name variants per pitch class (for scale spelling, validation, etc.)
 ENHARMONIC_NOTE_NAMES = [
-    ["B#", "C", "Dbb"],   # 0
+    ["B#", "C", "Dbb"],  # 0
     ["C#", "Db", "B##"],  # 1
     ["D", "C##", "Ebb"],  # 2
     ["D#", "Eb", "Fbb"],  # 3
-    ["E", "Fb", "D##"],   # 4
-    ["E#", "F", "Gbb"],   # 5
+    ["E", "Fb", "D##"],  # 4
+    ["E#", "F", "Gbb"],  # 5
     ["F#", "Gb", "E##"],  # 6
     ["G", "F##", "Abb"],  # 7
-    ["G#", "Ab"],          # 8
+    ["G#", "Ab"],  # 8
     ["A", "G##", "Bbb"],  # 9
     ["A#", "Bb", "Cbb"],  # 10
-    ["B", "Cb", "A##"],   # 11
+    ["B", "Cb", "A##"],  # 11
 ]
 # A dictionary that maps note names to their corresponding MIDI numbers
 base_midi_numbers = {
     "C": 0,
-    "B♯♯": 1, "B##": 1, "C♯": 1, "C#": 1,
-    "D♭": 1, "Db": 1,
-    "C♯♯": 2, "C##": 2, "D": 2,
-    "D♯": 3, "D#": 3, "E♭": 3, "Eb": 3,
-    "D♯♯": 4, "D##": 4, "E": 4, "Fb": 4, "F♭": 4,
-    "E♯": 5, "E#": 5, "F": 5,
-    "E♯♯": 6, "E##": 6, "F♯": 6, "F#": 6, "Gb": 6, "G♭": 6,
-    "F♯♯": 7, "F##": 7, "G": 7,
-    "G♯": 8, "G#": 8, "A♭": 8, "Ab": 8,
-    "G♯♯": 9, "G##": 9, "A": 9,
-    "A♯": 10, "A#": 10, "B♭": 10, "Bb": 10,
-    "A♯♯": 11, "A##": 11, "B": 11, "Cb": 11, "C♭": 11,
-    "B♯": 12, "B#": 12
+    "Dbb": 0,
+    "B♯♯": 1,
+    "B##": 1,
+    "C♯": 1,
+    "C#": 1,
+    "D♭": 1,
+    "Db": 1,
+    "C♯♯": 2,
+    "C##": 2,
+    "D": 2,
+    "Ebb": 2,
+    "D♯": 3,
+    "D#": 3,
+    "E♭": 3,
+    "Eb": 3,
+    "Fbb": 3,
+    "D♯♯": 4,
+    "D##": 4,
+    "E": 4,
+    "Fb": 4,
+    "F♭": 4,
+    "E♯": 5,
+    "E#": 5,
+    "F": 5,
+    "Gbb": 5,
+    "E♯♯": 6,
+    "E##": 6,
+    "F♯": 6,
+    "F#": 6,
+    "Gb": 6,
+    "G♭": 6,
+    "F♯♯": 7,
+    "F##": 7,
+    "G": 7,
+    "Abb": 7,
+    "G♯": 8,
+    "G#": 8,
+    "A♭": 8,
+    "Ab": 8,
+    "G♯♯": 9,
+    "G##": 9,
+    "A": 9,
+    "Bbb": 9,
+    "A♯": 10,
+    "A#": 10,
+    "B♭": 10,
+    "Bb": 10,
+    "Cbb": 10,
+    "A♯♯": 11,
+    "A##": 11,
+    "B": 11,
+    "Cb": 11,
+    "C♭": 11,
+    "B♯": 12,
+    "B#": 12,
 }
 
 # Scale intervals (semitones from root) for each mode
@@ -245,6 +287,7 @@ def apply_plotly_theme(fig):
     )
     return fig
 
+
 def scale(scale_letter, scale_mode):
     """Returns all the possible notes of a scale given the scale letter and mode.
 
@@ -286,11 +329,15 @@ def calculate_midi_number(note):
     Returns:
         int: A MIDI number that corresponds to the note.
     """
-    cleaned_pitch = note.pitch.strip().replace("♯", "#").replace("♭", "b").replace("𝄪", "##")
+    cleaned_pitch = (
+        note.pitch.strip().replace("♯", "#").replace("♭", "b").replace("𝄪", "##").replace("x", "##").replace("𝄫", "bb")
+    )
     for char in cleaned_pitch:
         if not char.isalpha() and char != "#":
             cleaned_pitch = cleaned_pitch.replace(char, "")
-    base_number = base_midi_numbers[cleaned_pitch]
+    base_number = base_midi_numbers.get(cleaned_pitch)
+    if base_number is None:
+        raise ValueError(f"Unrecognized note name: {note.pitch}") from None
     midi_number = base_number + ((note.octave + 1) * 12)
     return midi_number
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -97,16 +97,18 @@ SCALE_INTERVALS = {
 
 # Canonical duration definitions: name -> beats, sixteenths, display string, and aliases
 DURATION_MAP = {
-    "sixteenth": {"beats": 0.25, "sixteenths": 1,  "display": "1/16",  "aliases": ["16th"]},
-    "eighth":    {"beats": 0.5,  "sixteenths": 2,  "display": "1/8",   "aliases": ["8th"]},
-    "quarter":   {"beats": 1.0,  "sixteenths": 4,  "display": "1/4",   "aliases": []},
-    "half":      {"beats": 2.0,  "sixteenths": 8,  "display": "1/2",   "aliases": []},
-    "whole":     {"beats": 4.0,  "sixteenths": 16, "display": "1 bar", "aliases": []},
+    "sixteenth": {"beats": 0.25, "sixteenths": 1, "display": "1/16", "aliases": ["16th"]},
+    "eighth": {"beats": 0.5, "sixteenths": 2, "display": "1/8", "aliases": ["8th"]},
+    "quarter": {"beats": 1.0, "sixteenths": 4, "display": "1/4", "aliases": []},
+    "half": {"beats": 2.0, "sixteenths": 8, "display": "1/2", "aliases": []},
+    "whole": {"beats": 4.0, "sixteenths": 16, "display": "1 bar", "aliases": []},
 }
 
 # Derived lookups from DURATION_MAP
 DURATION_BEATS = {name: d["beats"] for name, d in DURATION_MAP.items()}
-DURATION_SIXTEENTHS_TO_DISPLAY = {d["sixteenths"]: d["display"] for d in DURATION_MAP.values()}
+DURATION_SIXTEENTHS_TO_DISPLAY = {
+    d["sixteenths"]: d["display"] for d in DURATION_MAP.values()
+}
 DURATION_KEYWORDS = {name: name for name in DURATION_MAP}
 for name, d in DURATION_MAP.items():
     for alias in d["aliases"]:
@@ -115,12 +117,22 @@ DURATION_BEATS_TO_NAME = {d["beats"]: name.title() for name, d in DURATION_MAP.i
 
 # Interval names (semitones 0-11 relative to root)
 INTERVAL_NAMES = [
-    "Root", "m2", "M2", "m3", "M3", "P4",
-    "Tritone", "P5", "m6", "M6", "m7", "M7",
+    "Root",
+    "m2",
+    "M2",
+    "m3",
+    "M3",
+    "P4",
+    "Tritone",
+    "P5",
+    "m6",
+    "M6",
+    "m7",
+    "M7",
 ]
 
 PLOTLY_BG = "#1a1a2e"
-PLOTLY_BG_ALT = "#252540"       # Slightly lighter (e.g. black key lanes)
+PLOTLY_BG_ALT = "#252540"  # Slightly lighter (e.g. black key lanes)
 PLOTLY_GRID = "#2a2a4a"
 PLOTLY_GRID_STRONG = "#4a4a6a"  # Bar boundaries
 PLOTLY_TEXT = "#e0e0e0"

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,7 +3,6 @@ This file contains utility functions for handling the creation of MIDI objects, 
 """
 
 import plotly.graph_objects as go
-import numpy as np
 import json
 import mido
 import os

--- a/src/utils.py
+++ b/src/utils.py
@@ -343,12 +343,9 @@ def calculate_midi_number(note):
     cleaned_pitch = (
         note.pitch.strip().replace("♯", "#").replace("♭", "b").replace("𝄪", "##").replace("x", "##").replace("𝄫", "bb")
     )
-    for char in cleaned_pitch:
-        if not char.isalpha() and char != "#":
-            cleaned_pitch = cleaned_pitch.replace(char, "")
-    base_number = base_midi_numbers.get(cleaned_pitch)
-    if base_number is None:
-        raise ValueError(f"Unrecognized note name: {note.pitch}") from None
+    if cleaned_pitch not in base_midi_numbers:
+        raise ValueError(f"Unrecognized note name: {note.pitch}")
+    base_number = base_midi_numbers[cleaned_pitch]
     midi_number = base_number + ((note.octave + 1) * 12)
     return midi_number
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,6 +128,14 @@ def test_scale_rejects_invalid_root_and_mode():
         utils.scale("C", "dorian")
 
 
+def test_advertised_enharmonic_spellings_convert_to_midi(note_factory):
+    for pitch_class_notes in utils.ENHARMONIC_NOTE_NAMES:
+        for pitch in pitch_class_notes:
+            note = note_factory(pitch=pitch)
+
+            assert isinstance(utils.calculate_midi_number(note), int)
+
+
 @pytest.mark.parametrize(
     ("pitch", "octave", "expected_midi_number"),
     [
@@ -146,6 +154,36 @@ def test_calculate_midi_number_normalizes_pitch_names(
     note = note_factory(pitch=pitch, octave=octave)
 
     assert utils.calculate_midi_number(note) == expected_midi_number
+
+
+@pytest.mark.parametrize(
+    ("pitch", "octave", "expected_midi_number"),
+    [
+        ("Dbb", 4, 60),
+        ("Ebb", 4, 62),
+        ("Fbb", 4, 63),
+        ("Gbb", 4, 65),
+        ("Abb", 4, 67),
+        ("Bbb", 4, 69),
+        ("Cbb", 4, 70),
+    ],
+)
+def test_calculate_midi_number_supports_ascii_double_flats(
+    note_factory,
+    pitch,
+    octave,
+    expected_midi_number,
+):
+    note = note_factory(pitch=pitch, octave=octave)
+
+    assert utils.calculate_midi_number(note) == expected_midi_number
+
+
+def test_calculate_midi_number_rejects_unknown_pitch_names(note_factory):
+    note = note_factory(pitch="H")
+
+    with pytest.raises(ValueError, match="Unrecognized note name"):
+        utils.calculate_midi_number(note)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Fix MIDI conversion so all advertised double-flat spellings round-trip correctly and malformed pitch names raise `ValueError` instead of being normalized incorrectly.

Fixes #20 

## Changes
- Added the missing ASCII double-flat spellings to `base_midi_numbers`.
- Updated `calculate_midi_number()` to validate against the lookup table directly and raise `ValueError` for unknown note spellings.
- Added regression tests for advertised enharmonic spellings, ASCII double flats, and malformed pitch strings.
- Applied light formatting cleanup in `src/utils.py` while touching the conversion path.

## Validation
- `python -m pytest tests/test_utils.py`
- `python -m pytest tests/test_midi_processing.py`
- `python -m pytest`

## Notes
- This keeps the current table-driven approach and avoids the broader parser refactor.