### PR TITLE
fix(ui): clarify generation stop waiting behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,5 @@ LoopGPT/
 - The quality of generated music depends on the prompt and model parameters.
 - Requires an active internet connection for API calls to model providers.
 - High API usage may incur significant costs.
+- The `Stop Waiting` control only detaches the UI from an in-flight request; it does not abort the provider call.
 - Audio preview still depends on external FluidSynth and FFmpeg installations even though a default SoundFont is bundled with the repo.

--- a/app.py
+++ b/app.py
@@ -377,9 +377,9 @@ def run_loop(
 ):
     """Run the loop generation process based on user inputs and selected model.
 
-    This is a generator function that yields progress updates, allowing the generation
-    to be cancelled by Gradio's cancellation mechanism. The API call runs in a background
-    thread while the generator periodically yields status updates.
+    This is a generator function that yields progress updates while the API call runs
+    in a background thread. Gradio can stop waiting for the generator, but that does
+    not cancel the in-flight provider request.
 
     Args:
         key (str): The key for the loop that the user selects from the dropdown.
@@ -395,9 +395,9 @@ def run_loop(
         claude_key (str): The Claude API key that the user inputs in the text box.
 
     Yields:
-         tuple: (file_path, audio_path, visualization, status_message, cancel_button_update,
+         tuple: (file_path, audio_path, visualization, status_message, stop_button_update,
              generation_id, saved_soundfont, current_audio_path) - intermediate yields
-             show progress and keep cancel visible, final yield contains the generated MIDI,
+             show progress and keep the stop-waiting control visible, final yield contains the generated MIDI,
              audio, and persisted audio metadata for rerendering.
     """
     workspace = None
@@ -415,10 +415,10 @@ def run_loop(
         prompt = f"{key} {scale} {description}."
         selected_soundfont = get_selected_soundfont(soundfont_choice)
 
-        # Yield initial status and show cancel button - this is a cancellation checkpoint
+        # Yield initial status and show the stop-waiting button.
         yield None, None, None, "Working on it...", gr.update(visible=True), None, None, None
 
-        # Run API call in background thread so we can yield periodically for cancellation
+        # Run API call in a background thread so the UI can stop waiting.
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(
                 runs.generate_midi,
@@ -429,7 +429,7 @@ def run_loop(
                 effort=effort,
             )
 
-            # Poll for completion, yielding periodically to allow cancellation
+            # Poll for completion, yielding periodically so Gradio can interrupt the wait.
             while not future.done():
                 time.sleep(0.5)  # Check every 500ms
                 yield None, None, None, "Generating MIDI...", gr.update(visible=True), None, None, None
@@ -485,7 +485,7 @@ def run_loop(
         persisted_audio_path = saved_generation.audio_path
         saved_soundfont = saved_generation.soundfont
 
-        # Final yield with the completed result and hide cancel button
+        # Final yield with the completed result and hide the stop-waiting button.
         yield (
             saved_generation.midi_path,
             persisted_audio_path,
@@ -498,7 +498,7 @@ def run_loop(
         )
 
     except Exception as e:
-        # Catch any exception and yield the error message, hide cancel button
+        # Catch any exception and yield the error message, hide the stop-waiting button.
         yield None, None, None, str(e), gr.update(visible=False), None, None, None
     finally:
         if workspace is not None and not finalized:
@@ -881,7 +881,7 @@ def create_demo(playback_status=None):
                             )
                     with gr.Row():
                         prog_button = gr.Button("Generate Loop", variant="primary")
-                        cancel_button = gr.Button("Cancel", variant="stop", visible=False)
+                        cancel_button = gr.Button("Stop Waiting", variant="stop", visible=False)
 
                     # Output section
                     with gr.Row():
@@ -944,8 +944,8 @@ def create_demo(playback_status=None):
                             effort_input,
                         ],
                     )
-                    # When the user clicks the button, run the loop generation function based on the current inputs
-                    # Capture the event so we can cancel it with the cancel button
+                    # When the user clicks the button, run the loop generation function based on the current inputs.
+                    # Capture the event so the stop-waiting button can detach the UI from the in-flight request.
                     gen_event = prog_button.click(
                         run_loop,
                         inputs=[
@@ -972,13 +972,13 @@ def create_demo(playback_status=None):
                             current_audio_path,
                         ],
                     )
-                    # Cancel button stops waiting for the API response and hides itself
+                    # Stop Waiting detaches the UI from the API response wait and hides itself.
                     cancel_button.click(
                         fn=lambda: (
                             None,
                             None,
                             None,
-                            "Generation cancelled.",
+                            "Stopped waiting. The provider request may still finish in the background.",
                             gr.update(visible=False),
                             None,
                             None,

--- a/app.py
+++ b/app.py
@@ -881,7 +881,7 @@ def create_demo(playback_status=None):
                             )
                     with gr.Row():
                         prog_button = gr.Button("Generate Loop", variant="primary")
-                        cancel_button = gr.Button("Stop Waiting", variant="stop", visible=False)
+                        stop_waiting_button = gr.Button("Stop Waiting", variant="stop", visible=False)
 
                     # Output section
                     with gr.Row():
@@ -966,14 +966,14 @@ def create_demo(playback_status=None):
                             audio_output,
                             vis_output,
                             error_message,
-                            cancel_button,
+                            stop_waiting_button,
                             current_generation_id,
                             current_saved_soundfont,
                             current_audio_path,
                         ],
                     )
                     # Stop Waiting detaches the UI from the API response wait and hides itself.
-                    cancel_button.click(
+                    stop_waiting_button.click(
                         fn=lambda: (
                             None,
                             None,
@@ -989,7 +989,7 @@ def create_demo(playback_status=None):
                             audio_output,
                             vis_output,
                             error_message,
-                            cancel_button,
+                            stop_waiting_button,
                             current_generation_id,
                             current_saved_soundfont,
                             current_audio_path,
@@ -1139,7 +1139,7 @@ def create_demo(playback_status=None):
             outputs=[history_dropdown, history_html],
         )
 
-        # Also refresh history after generation completes (when cancel button becomes hidden)
+        # Also refresh history after generation completes (when the stop-waiting button becomes hidden)
         # We do this by having the generation flow trigger a refresh
         gen_event.then(
             get_rerender_button_update,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -100,7 +100,7 @@ def test_run_loop_cleans_workspace_when_generator_closes_before_finalization(
     )
 
     def fail_midi_to_mp3(*args, **kwargs):
-        raise AssertionError("midi_to_mp3 should not run before this cancellation point")
+        raise AssertionError("midi_to_mp3 should not run before this stop-waiting point")
 
     monkeypatch.setattr(app, "midi_to_mp3", fail_midi_to_mp3)
     monkeypatch.setattr(app, "visualize_midi_plotly", lambda midi: "viz")


### PR DESCRIPTION
## Summary
This PR aligns the generation control with what the app actually does today. The UI no longer implies that clicking the button cancels the provider request; it now clearly communicates that it only stops waiting for the in-flight response.

Fixes #23 

## Changes
- Renamed the Gradio control label from `Cancel` to `Stop Waiting`.
- Updated the related handler variable names and inline comments to match the new semantics.
- Revised the `run_loop` docstring and status messaging so they describe detaching from the request instead of cancelling it.
- Added a README note explaining that `Stop Waiting` does not abort the provider call.
- Updated the focused app test wording so it matches the new terminology.

## Validation
- `pytest tests/test_app.py tests/test_history.py`
- Result: `27 passed, 1 warning`

## Notes
- This is a UX and wording fix only. It does not change provider execution behavior.