### PR TITLE
Fix Claude Sonnet 5 effort level options

### DIFF
--- a/model_list.json
+++ b/model_list.json
@@ -279,7 +279,7 @@
         "Anthropic": {
             "claude-sonnet-5":{
                 "extended_thinking": false,
-                "effort_options": ["low", "medium", "high"],
+                "effort_options": ["low", "medium", "high", "xhigh", "max"],
                 "max_tokens": 128000,
                 "cost": {
                     "input": 3.00,


### PR DESCRIPTION
## Summary

I totally slipped staging this change where I caught that the initial agent working on this missed that Claude Sonnet 5 has additional thinking levels `xhigh` and `max`. This is the only change that is part of this PR to patch that fix quick.

## Validation

- pytest: 121 passed, 2 warnings