### PR TITLE
The revival of Claude Fable 5

### DIFF
--- a/model_list.json
+++ b/model_list.json
@@ -277,6 +277,18 @@
             }
         },
         "Anthropic": {
+            "claude-fable-5":{
+                "extended_thinking": false,
+                "effort_options": ["low", "medium", "high", "xhigh", "max"],
+                "max_tokens": 128000,
+                "cost": {
+                    "input": 10.00,
+                    "5m cache input": 12.50,
+                    "1h cache input": 20.00,
+                    "cache hits/refreshes": 1.00,
+                    "output": 50.00
+                }
+            },
             "claude-sonnet-5":{
                 "extended_thinking": false,
                 "effort_options": ["low", "medium", "high", "xhigh", "max"],


### PR DESCRIPTION
## Summary

Claude Fable 5 has been added to this project #14 , and then quickly removed #15 as the govenrment put a supply chain restriction on the model. 

Finally, the wait is over. The US government lifted the restrictions and Anthropic returned the model to be publicly available. The only code change made here was to add the model metadata to the `model_list.json` registry.

## Validation
- pytest: 121 passed, 2 warnings
- Local app testing:
  - Generated multiple loops with various reasoning effort levels selected using claude-fable-5.
  - Verified the new logic preserves legacy behavior for non-claude-fable-5 models.