### PR TITLE
Clamp MIDI notes at the four-bar boundary

### DIFF
--- a/src/midi_processing.py
+++ b/src/midi_processing.py
@@ -41,6 +41,7 @@ def loop_to_midi(midi, loop, times_as_string=True):
     # Calculated ticks per sixteenth note, based on provided ticks per beat (quarter note).
     ticks_per_beat = int(midi.ticks_per_beat / 4)
     bar_length = 16 * ticks_per_beat 
+    final_bar_ticks = 4 * bar_length
     
     # Initialize a list to hold all note events (on and off).
     events = []
@@ -62,6 +63,9 @@ def loop_to_midi(midi, loop, times_as_string=True):
             note_start_tick = bar_offset + (start_beat - 1) * ticks_per_beat
             note_duration_ticks = duration * ticks_per_beat
             note_end_tick = note_start_tick + note_duration_ticks
+            if note_end_tick > final_bar_ticks:
+                logger.warning("[MIDI] Note output clamped to the 4-bar loop boundary.")
+                note_end_tick = final_bar_ticks
             
             # Append note on and note off events.
             events.append((note_start_tick, 'note_on', note))
@@ -95,7 +99,6 @@ def loop_to_midi(midi, loop, times_as_string=True):
         track.append(msg)
         prev_tick = event_time
     
-    final_bar_ticks = 4 * 16 * ticks_per_beat
     if prev_tick < final_bar_ticks:
         remaining = final_bar_ticks - prev_tick
         track.append(MetaMessage('end_of_track', time=remaining))

--- a/tests/test_midi_processing.py
+++ b/tests/test_midi_processing.py
@@ -3,6 +3,16 @@ from mido import Message, MetaMessage, MidiFile, MidiTrack
 from src.midi_processing import loop_to_midi, midi_to_loop
 
 
+def _note_events_with_absolute_times(midi):
+    events = []
+    absolute_time = 0
+    for msg in midi.tracks[0]:
+        absolute_time += msg.time
+        if msg.type != "end_of_track":
+            events.append((msg.type, msg.note, absolute_time))
+    return events
+
+
 def test_loop_to_midi_orders_note_off_before_note_on_at_same_tick(loop_factory, note_factory):
     loop = loop_factory(
         bars=[
@@ -45,6 +55,45 @@ def test_loop_to_midi_clamps_out_of_range_velocity(loop_factory, note_factory):
     note_messages = [msg for msg in midi.tracks[0] if msg.type != "end_of_track"]
 
     assert [msg.velocity for msg in note_messages] == [127, 127]
+
+
+def test_loop_to_midi_allows_notes_to_cross_early_bar_boundaries(loop_factory, note_factory):
+    loop = loop_factory(
+        bars=[
+            [note_factory(pitch="C", start_beat=16, duration=4)],
+            [],
+            [],
+            [],
+        ]
+    )
+    midi = MidiFile(ticks_per_beat=480)
+
+    loop_to_midi(midi, loop, times_as_string=False)
+
+    assert _note_events_with_absolute_times(midi) == [
+        ("note_on", 60, 1800),
+        ("note_off", 60, 2280),
+    ]
+
+
+def test_loop_to_midi_clamps_notes_at_four_bar_boundary(loop_factory, note_factory, caplog):
+    loop = loop_factory(
+        bars=[
+            [],
+            [],
+            [],
+            [note_factory(pitch="C", start_beat=16, duration=4)],
+        ]
+    )
+    midi = MidiFile(ticks_per_beat=480)
+
+    loop_to_midi(midi, loop, times_as_string=False)
+
+    assert _note_events_with_absolute_times(midi) == [
+        ("note_on", 60, 7560),
+        ("note_off", 60, 7680),
+    ]
+    assert "clamped to the 4-bar loop boundary" in caplog.text
 
 
 def test_midi_to_loop_round_trips_integer_timing(sample_loop, midi_builder):


### PR DESCRIPTION
## Summary

Fixes Issue #19 

- Clamp note-off output so notes that extend past the end of bar 4 do not emit beyond the loop boundary.
- Keep valid note durations intact for notes that cross earlier bar boundaries.
- Clamp notes gracefully in `loop_to_midi` instead of hard failing as a validation rule within loop schema. 
- Add regression tests covering cross-bar notes and boundary-clamped notes, including the warning log.

## Testing
- Added unit coverage in `tests/test_midi_processing.py` for note event timing and clamp behavior.
- pytest: 123 passing, 2 warnings