### PR TITLE
Add gpt-5.6 models to OpenAI registry

### DIFF
--- a/model_list.json
+++ b/model_list.json
@@ -1,6 +1,36 @@
 {
     "models": {
         "OpenAI": {
+            "gpt-5.6-sol": {
+                "extended_thinking": true,
+                "effort_options": ["none", "low", "medium", "high", "xhigh", "max"],
+                "max_tokens": 128000,
+                "cost": {
+                    "input": 5.00,
+                    "cached input": 0.50,
+                    "output": 30.00
+                }
+            },
+            "gpt-5.6-terra": {
+                "extended_thinking": true,
+                "effort_options": ["none", "low", "medium", "high", "xhigh", "max"],
+                "max_tokens": 128000,
+                "cost": {
+                    "input": 2.50,
+                    "cached input": 0.25,
+                    "output": 15.00
+                }
+            },
+            "gpt-5.6-luna": {
+                "extended_thinking": true,
+                "effort_options": ["none", "low", "medium", "high", "xhigh", "max"],
+                "max_tokens": 128000,
+                "cost": {
+                    "input": 1.00,
+                    "cached input": 0.10,
+                    "output": 6.00
+                }
+            },
             "gpt-5.5": {
                 "extended_thinking": true,
                 "effort_options": ["none", "low", "medium", "high", "xhigh"],


### PR DESCRIPTION
## Summary
- Added `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the OpenAI model registry.
- Marked each model as supporting extended thinking with `effort_options` from `none` through `max`.
- Set per-model token limits and pricing metadata for input, cached input, and output usage.

## Testing
- pytest: 123 passed, 2 warnings
- In-app testing: Generated multiple MIDI loops with GPT 5.6 Sol, Terra, and Luna across various reasoning effort levels.